### PR TITLE
fix: ollama docker-compose

### DIFF
--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -2,7 +2,8 @@ services:
 
   llm-api:
     image: ghcr.io/berriai/litellm:main-v1.10.3
-    command: --model ollama/llama2 --api_base http://host.docker.internal:11434 --host 0.0.0.0 --port 3000
+    command: ["/bin/sh", "-c", "pip install async_generator && litellm --model ollama/llama2 --api_base http://host.docker.internal:11434 --host 0.0.0.0 --port 3000"]
+    entrypoint: []
     platform: linux/amd64
     ports:
       - "3000:3000"


### PR DESCRIPTION
This will fix the problem with the missing python dependency without manually installing it in the container