### PR TITLE
Specify exact endpoint that Bionic-GPT uses in the documentation.

### DIFF
--- a/website/content/blog/llm-hardware/index.md
+++ b/website/content/blog/llm-hardware/index.md
@@ -122,7 +122,7 @@ That's with 192GB of memory so you're looking at a system cost of $5,599.
 
 ## API Requirements
 
-Most application that use LLM's rely on an API and the standard API at the moment is the Open AI Rest API.
+Most application that use LLM's rely on an API and the standard API at the moment is the Open AI `chat/completions` [API](https://platform.openai.com/docs/api-reference/chat).
 
 Any API will need to ideally follow that standard and support the following
 

--- a/website/content/docs/administration/external-api.md
+++ b/website/content/docs/administration/external-api.md
@@ -5,7 +5,7 @@ weight = 50
 sort_by = "weight"
 +++
 
-If you're already running an LLM that supports the Open AI API in your organisation or on your local machine you may want to connect to it instead of the one we provide.
+If you're already running an LLM that supports the Open AI `chat/completions` [API](https://platform.openai.com/docs/api-reference/chat) in your organisation or on your local machine you may want to connect to it instead of the one we provide.
 
 
 ## Add a new model

--- a/website/content/docs/production/add-a-model.md
+++ b/website/content/docs/production/add-a-model.md
@@ -8,18 +8,18 @@ By "adding a remote model" we mean a model that's not running in your Kubernetes
 
 You basically have 2 options.
 
-1. The provider supports the Open AI Rest API.
+1. The provider supports the Open AI `chat/completions` [API](https://platform.openai.com/docs/api-reference/chat).
 1. They don't in which case we need to install Lite LLM.
 
-## The provider supports the Open AI Rest API
+## The provider supports the Open AI `chat/completions` API
 
 Great news. Add the URL for your provider and any API keys directly into the models section of the user interface.
 
 ![Alt text](../../running-locally/bionic-setup.png "Adding Models")
 
-## For providers that don't support the Open AI Rest API (Work in Progress)
+## For providers that don't support the Open AI `chat/completions` API (Work in Progress)
 
-Luckily the guys at [Lite LLM](https://litellm.ai/) have got you covered. They basically connect to any provider and create an Open AI Rest API endpoint to your model.
+Luckily the guys at [Lite LLM](https://litellm.ai/) have got you covered. They basically connect to any provider and create an Open AI `chat/completions` API endpoint to your model.
 
 You'll need to add the following to the `Pulumi.yaml` file.
 

--- a/website/content/docs/production/k8s-gpu.md
+++ b/website/content/docs/production/k8s-gpu.md
@@ -12,6 +12,6 @@ We recommend you run [Hugging Face TGI](https://github.com/huggingface/text-gene
 
 ## LiteLLM
 
-Lite LLM is a proxy that sits between Bionic and TGI and converts the TGI rest API into an Open AI compatible API as well as handling prompt templating.
+Lite LLM is a proxy that sits between Bionic and TGI and converts the TGI rest API into an Open AI compatible `chat/completions` API which is responsible for handling prompt templating.
 
 ![Alt text](../../running-locally/arch.png "Architecture")


### PR DESCRIPTION
Fix documentation reference that just specified "Rest API", and clarified the exact endpoint (`chat/completions`) that the project relies on.