### PR TITLE
fix: dns llm-api

### DIFF
--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -5,6 +5,9 @@ services:
     command: ["/bin/sh", "-c", "pip install async_generator && litellm --model ollama/llama2 --api_base http://host.docker.internal:11434 --host 0.0.0.0 --port 3000"]
     entrypoint: []
     platform: linux/amd64
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     ports:
       - "3000:3000"
     extra_hosts:


### PR DESCRIPTION
I found out that in some of our Macs (ARM) pip fails to install packages due dns errors:

`urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x7ffffc6ce4f0>: Failed to establish a new connection: [Errno -5] No address associated with hostname`

It didn't happen in all of them but in many, all of them were running Docker Desktop `v4.26.0` installed in the exactly same way (brew). Adding Google DNS mitigated the problem in all of them and worked fine also in the ones that were working.