### PR TITLE
Fix issue with Company prompt

### DIFF
--- a/crates/db/queries/prompts.sql
+++ b/crates/db/queries/prompts.sql
@@ -97,7 +97,7 @@ FROM
 WHERE
     p.id = :prompts_id
 AND
-    p.model_id IN (
+    (p.model_id IN (
         SELECT id FROM models WHERE team_id IN(
             SELECT team_id 
             FROM team_users 
@@ -108,7 +108,7 @@ AND
     OR 
         (p.visibility='Company')
     OR 
-        (p.visibility = 'Private' AND created_by = current_app_user()) 
+        (p.visibility = 'Private' AND created_by = current_app_user()))
 ORDER BY updated_at;
 
 --! prompt_by_api_key : Prompt


### PR DESCRIPTION
When more than one prompt exists and any of them is Company, more than one prompt is returned which causes an error.  This commit fixes the issue by limiting the AND condition.

Issue was descibed here:
https://github.com/bionic-gpt/bionic-gpt/issues/410