### PR TITLE
Improve hero section styling

### DIFF
--- a/crates/static-website/src/components/hero.rs
+++ b/crates/static-website/src/components/hero.rs
@@ -6,12 +6,13 @@ use crate::routes::marketing;
 pub fn Hero(title: String, subtitle: String) -> Element {
     rsx! {
         section {
+            class: "py-16 bg-gradient-to-r from-secondary/10 via-accent/10 to-primary/10",
             div {
                 class: "flex justify-center text-center",
                 div {
-                    class: "max-w-lg",
+                    class: "max-w-lg px-8 py-4 rounded-box shadow-xl backdrop-blur-sm",
                     h1 {
-                        class: "text-5xl font-bold",
+                        class: "text-5xl font-extrabold mb-4 bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent",
                         "{title}"
                     }
                     p {
@@ -21,9 +22,14 @@ pub fn Hero(title: String, subtitle: String) -> Element {
                     div {
                         class: "flex gap-2 justify-center",
                         a {
-                            class: "btn btn-primary",
+                            class: "btn btn-primary shadow",
                             href: marketing::Contact {}.to_string(),
                             "Book a Call"
+                        }
+                        a {
+                            class: "btn btn-secondary btn-outline",
+                            href: marketing::Pricing {}.to_string(),
+                            "View Pricing"
                         }
                     }
                 }

--- a/crates/static-website/src/components/video_hero.rs
+++ b/crates/static-website/src/components/video_hero.rs
@@ -9,13 +9,14 @@ use crate::routes::marketing;
 pub fn VideoHero(title: String, subtitle: String, video_id: String, claim: String) -> Element {
     rsx! {
         section {
+            class: "py-16 md:py-24 bg-gradient-to-br from-base-200 to-base-100",
             div {
-                class: "md:flex flex-row gap-8 text-center md:text-left",
+                class: "md:flex flex-row gap-8 items-center text-center md:text-left",
                 div {
                     class: "flex-1",
                     div {
                         h1 {
-                            class: "text-primary text-2xl md:text-5xl font-bold",
+                            class: "text-3xl md:text-5xl font-extrabold mb-4 bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent",
                             "{title}"
                         }
                     }
@@ -23,6 +24,7 @@ pub fn VideoHero(title: String, subtitle: String, video_id: String, claim: Strin
                 div {
                     class: "flex-1",
                     lite-youtube{
+                        class: "rounded-box shadow-2xl",
                         videoid: "{video_id}"
                     }
                 }
@@ -35,7 +37,7 @@ pub fn VideoHero(title: String, subtitle: String, video_id: String, claim: Strin
                 }
                 div {
                     a {
-                        class: "btn btn-secondary",
+                        class: "btn btn-primary btn-wide shadow",
                         href: marketing::Contact {}.to_string(),
                         "Book a Call"
                     }


### PR DESCRIPTION
## Summary
- add gradient styling and second CTA button to hero
- style video hero with gradient background and shadowed video

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6840863758c48320a60764e871249bd0