### PR TITLE
Add AuthorizedTransaction helper

### DIFF
--- a/crates/db/authorized.rs
+++ b/crates/db/authorized.rs
@@ -1,0 +1,60 @@
+use crate::{self as db, authz, Pool, Transaction};
+use deadpool_postgres::Client;
+use std::fmt;
+
+pub struct AuthorizedTransaction<'a> {
+    pub client: Client,
+    pub transaction: Transaction<'a>,
+    pub rbac: authz::Rbac,
+}
+
+#[derive(Debug)]
+pub enum AuthorizedTransactionError {
+    PoolError(db::PoolError),
+    PostgresError(db::TokioPostgresError),
+}
+
+impl fmt::Display for AuthorizedTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthorizedTransactionError::PoolError(e) => write!(f, "Pool Error: {}", e),
+            AuthorizedTransactionError::PostgresError(e) => write!(f, "Postgres Error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for AuthorizedTransactionError {}
+
+impl From<db::PoolError> for AuthorizedTransactionError {
+    fn from(err: db::PoolError) -> Self {
+        AuthorizedTransactionError::PoolError(err)
+    }
+}
+
+impl From<db::TokioPostgresError> for AuthorizedTransactionError {
+    fn from(err: db::TokioPostgresError) -> Self {
+        AuthorizedTransactionError::PostgresError(err)
+    }
+}
+
+impl<'a> AuthorizedTransaction<'a> {
+    pub async fn new(
+        pool: &Pool,
+        auth: &authz::Authentication,
+        team_id: i32,
+    ) -> Result<Self, AuthorizedTransactionError> {
+        let mut client = pool.get().await?;
+        let transaction = client.transaction().await?;
+        let rbac = authz::get_permissions(&transaction, auth, team_id).await?;
+        Ok(Self {
+            client,
+            transaction,
+            rbac,
+        })
+    }
+
+    pub async fn commit(self) -> Result<(), AuthorizedTransactionError> {
+        self.transaction.commit().await?;
+        Ok(())
+    }
+}

--- a/crates/db/lib.rs
+++ b/crates/db/lib.rs
@@ -1,9 +1,11 @@
+pub mod authorized;
 pub mod authz;
 pub mod customer_keys;
 pub mod vector_search;
 
 use std::str::FromStr;
 
+pub use authorized::{AuthorizedTransaction, AuthorizedTransactionError};
 pub use cornucopia_async::Params;
 pub use deadpool_postgres::{Pool, PoolError, Transaction};
 pub use queries::api_keys::ApiKey;

--- a/crates/web-server/errors.rs
+++ b/crates/web-server/errors.rs
@@ -87,6 +87,12 @@ impl From<db::PoolError> for CustomError {
     }
 }
 
+impl From<db::AuthorizedTransactionError> for CustomError {
+    fn from(err: db::AuthorizedTransactionError) -> CustomError {
+        CustomError::Database(err.to_string())
+    }
+}
+
 impl From<object_storage::StorageError> for CustomError {
     fn from(err: object_storage::StorageError) -> CustomError {
         CustomError::Database(err.to_string())


### PR DESCRIPTION
## Summary
- move `AuthorizedTransaction` into the `db` crate and expose it
- refactor API key and document handlers to use the new location
- add conversion from `AuthorizedTransactionError` to `CustomError`
- clean up `web-server` module exports

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: build script panicked for `db` crate)*

------
https://chatgpt.com/codex/tasks/task_e_68429dd44d748320aa481101ddeda675