### PR TITLE
fix: migration missing prompt field

### DIFF
--- a/crates/db/migrations/20250606081200_migrate_data_and_update_api_chats.sql
+++ b/crates/db/migrations/20250606081200_migrate_data_and_update_api_chats.sql
@@ -57,6 +57,7 @@ UPDATE api_chats SET
 -- Insert assistant responses for api_chats that have responses
 INSERT INTO api_chats (
     api_key_id,
+    prompt,
     content,
     role,
     status,
@@ -65,6 +66,7 @@ INSERT INTO api_chats (
 )
 SELECT 
     api_key_id,
+    '' AS prompt,
     response,
     'Assistant'::chat_role,
     status,


### PR DESCRIPTION
## Summary
- fix data migration to supply placeholder `prompt` value when inserting assistant chat rows

## Testing
- `cargo fmt --all --check`
- `DATABASE_URL=postgres://user:pass@localhost/db cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: cornucopia missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843cfa4c35c8320ba926890fe608192