### PR TITLE
Remove dbg and log errors

### DIFF
--- a/crates/llm-proxy/synthesize.rs
+++ b/crates/llm-proxy/synthesize.rs
@@ -40,7 +40,7 @@ pub async fn synthesize(
                 .unwrap())
         }
         Err(err) => {
-            dbg!(&err);
+            tracing::error!("Error creating request: {:?}", err);
             Err(CustomError::FaultySetup(err.to_string()))
         }
     }


### PR DESCRIPTION
## Summary
- remove debugging statement in `synthesize` and log the error with `tracing::error!`

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_6843d36dc8a0832091dcbdf86eaa6501