### PR TITLE
Fix llm-proxy dev dependency

### DIFF
--- a/crates/llm-proxy/Cargo.toml
+++ b/crates/llm-proxy/Cargo.toml
@@ -27,4 +27,6 @@ tower-http = { version = "0.5", features = ["fs", "cors"] }
 # Tiktoken counts our token usage for prompts
 tiktoken-rs = { version = "0.5.4" }
 base64 = { version = "0.13.1" }
+
+[dev-dependencies]
 time = "0.3.36"


### PR DESCRIPTION
## Summary
- move `time` from regular dependencies to `dev-dependencies`
- ensure `Cargo.toml` ends with a newline

## Testing
- `cargo check --workspace` *(fails: called `Option::unwrap()` on a `None` value)*

------
https://chatgpt.com/codex/tasks/task_e_6843d3754eb4832092b4817748abc89a