### PR TITLE
Fix token role mapping

### DIFF
--- a/crates/llm-proxy/token_count.rs
+++ b/crates/llm-proxy/token_count.rs
@@ -5,7 +5,15 @@ pub fn token_count(messages: Vec<ChatCompletionMessage>) -> i32 {
     let messages: Vec<ChatCompletionRequestMessage> = messages
         .iter()
         .map(|msg| ChatCompletionRequestMessage {
-            role: "user".to_string(),
+            role: match msg.role {
+                ChatCompletionMessageRole::System => "system",
+                ChatCompletionMessageRole::User => "user",
+                ChatCompletionMessageRole::Assistant => "assistant",
+                ChatCompletionMessageRole::Function => "function",
+                ChatCompletionMessageRole::Tool => "tool",
+                ChatCompletionMessageRole::Developer => "developer",
+            }
+            .to_string(),
             content: msg.content.clone(),
             name: None,
             function_call: None,


### PR DESCRIPTION
## Summary
- map `ChatCompletionMessageRole` variants to the correct role strings when counting tokens

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6843d379fd9c8320915833e31a4eec63