### PR TITLE
Remove unwrap panics from llm-proxy

### DIFF
--- a/crates/llm-proxy/sse_chat_error.rs
+++ b/crates/llm-proxy/sse_chat_error.rs
@@ -67,7 +67,7 @@ pub fn string_to_chunk(content: &str) -> CompletionChunk {
         }],
     };
     CompletionChunk {
-        delta: serde_json::to_string(&delta).unwrap(),
+        delta: serde_json::to_string(&delta).unwrap_or_default(),
         merged: None,
         snapshot: "".to_string(),
     }

--- a/crates/llm-proxy/synthesize.rs
+++ b/crates/llm-proxy/synthesize.rs
@@ -36,8 +36,7 @@ pub async fn synthesize(
             let response_builder = Response::builder().status(response.status().as_u16());
             Ok(response_builder
                 .body(Body::from_stream(response.bytes_stream()))
-                // This unwrap is fine because the body is empty here
-                .unwrap())
+                .map_err(|e| CustomError::FaultySetup(e.to_string()))?)
         }
         Err(err) => {
             dbg!(&err);

--- a/crates/llm-proxy/token_count.rs
+++ b/crates/llm-proxy/token_count.rs
@@ -12,7 +12,7 @@ pub fn token_count(messages: Vec<ChatCompletionMessage>) -> i32 {
         })
         .collect();
 
-    num_tokens_from_messages("gpt-4", &messages).unwrap() as i32
+    num_tokens_from_messages("gpt-4", &messages).unwrap_or(0) as i32
 }
 
 pub fn token_count_from_string(message: &str) -> i32 {


### PR DESCRIPTION
## Summary
- map invalid API key errors to `CustomError`
- propagate DB errors instead of unwrapping
- convert more reverse proxy unwraps to proper error handling
- avoid panic in SSE error helper
- make synthesize endpoint return error on invalid response build
- avoid panic in token count helper

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6843d33861d08320b24e9980c1f3901e