### PR TITLE
Fix request-body param handling

### DIFF
--- a/crates/integrations/open_api_v3_integration.rs
+++ b/crates/integrations/open_api_v3_integration.rs
@@ -520,7 +520,13 @@ impl ToolInterface for ExternalIntegrationTool {
         tracing::debug!("Making request to URL: {} using method: {}", url, method);
 
         // Determine if we should send a request body
-        let has_request_body = !request_body_params.as_object().unwrap().is_empty();
+        let body_obj = request_body_params.as_object();
+        let has_request_body = body_obj.map_or(false, |obj| !obj.is_empty());
+        if body_obj.is_none() {
+            return Err(serde_json::json!({
+                "error": "Malformed request body arguments"
+            }));
+        }
 
         // Make the request based on the HTTP method
         let response = match method.to_uppercase().as_str() {


### PR DESCRIPTION
## Summary
- avoid panic when determining if a request body exists
- return an error when request-body params aren't an object

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68445ab8f908832092f10275f6f40e58