### PR TITLE
Improve OAuth2 detection

### DIFF
--- a/crates/integrations/oauth2/detection.rs
+++ b/crates/integrations/oauth2/detection.rs
@@ -1,19 +1,10 @@
+use oas3::spec::{ObjectOrReference, SecurityScheme};
+
 /// Check if an integration has OAuth2 support
 pub fn has_oauth2_support(integration: &db::queries::integrations::Integration) -> bool {
     if let Some(definition) = &integration.definition {
         if let Ok(spec) = oas3::from_json(definition.to_string()) {
-            if let Some(components) = &spec.components {
-                for security_scheme in components.security_schemes.values() {
-                    if let Ok(scheme_value) = serde_json::to_value(security_scheme) {
-                        if let Some(scheme_type) = scheme_value.get("type").and_then(|t| t.as_str())
-                        {
-                            if scheme_type == "oauth2" {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
+            return has_oauth2_security(&spec);
         }
     }
     false
@@ -22,15 +13,39 @@ pub fn has_oauth2_support(integration: &db::queries::integrations::Integration) 
 /// Check if an OpenAPI spec has OAuth2 security schemes
 pub fn has_oauth2_security(spec: &oas3::OpenApiV3Spec) -> bool {
     if let Some(components) = &spec.components {
-        for security_scheme in components.security_schemes.values() {
-            if let Ok(scheme_value) = serde_json::to_value(security_scheme) {
-                if let Some(scheme_type) = scheme_value.get("type").and_then(|t| t.as_str()) {
-                    if scheme_type == "oauth2" {
-                        return true;
-                    }
+        for scheme_ref in components.security_schemes.values() {
+            if let Ok(scheme) = scheme_ref.resolve(spec) {
+                if matches!(scheme, SecurityScheme::OAuth2 { .. }) {
+                    return true;
                 }
             }
         }
     }
     false
+}
+
+/// OAuth2 configuration extracted from a security scheme
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuth2Config {
+    pub authorization_url: String,
+    pub token_url: String,
+    pub scopes: Vec<String>,
+}
+
+/// Retrieve OAuth2 configuration from an OpenAPI spec
+pub fn get_oauth2_config(spec: &oas3::OpenApiV3Spec) -> Option<OAuth2Config> {
+    let components = spec.components.as_ref()?;
+    for scheme_ref in components.security_schemes.values() {
+        if let Ok(SecurityScheme::OAuth2 { flows, .. }) = scheme_ref.resolve(spec) {
+            if let Some(flow) = flows.authorization_code {
+                let scopes = flow.scopes.keys().cloned().collect();
+                return Some(OAuth2Config {
+                    authorization_url: flow.authorization_url.to_string(),
+                    token_url: flow.token_url.to_string(),
+                    scopes,
+                });
+            }
+        }
+    }
+    None
 }

--- a/crates/integrations/oauth2/mod.rs
+++ b/crates/integrations/oauth2/mod.rs
@@ -1,3 +1,3 @@
 pub mod detection;
 
-pub use detection::has_oauth2_support;
+pub use detection::{get_oauth2_config, has_oauth2_support, OAuth2Config};

--- a/crates/integrations/src/oauth2/test.rs
+++ b/crates/integrations/src/oauth2/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::detection::has_oauth2_security;
+    use super::detection::{get_oauth2_config, has_oauth2_security};
     use oas3::OpenApiV3;
     use serde_json;
 
@@ -51,8 +51,16 @@ mod tests {
 
         let spec: OpenApiV3 = serde_json::from_str(spec_json).unwrap();
         let has_oauth2 = has_oauth2_security(&spec);
-        
+
         assert!(has_oauth2, "OAuth2 should be detected in the test spec");
+
+        let config = get_oauth2_config(&spec).expect("config should be parsed");
+        assert_eq!(
+            config.authorization_url,
+            "https://example.com/oauth/authorize"
+        );
+        assert_eq!(config.token_url, "https://example.com/oauth/token");
+        assert_eq!(config.scopes, vec!["read".to_string()]);
     }
 
     #[test]
@@ -81,7 +89,8 @@ mod tests {
 
         let spec: OpenApiV3 = serde_json::from_str(spec_json).unwrap();
         let has_oauth2 = has_oauth2_security(&spec);
-        
+
         assert!(!has_oauth2, "OAuth2 should not be detected in spec without OAuth2");
+        assert!(get_oauth2_config(&spec).is_none(), "No config should be returned");
     }
 }


### PR DESCRIPTION
## Summary
- rewrite OAuth2 detection to resolve security schemes
- add helper for pulling OAuth2 config
- expose new helper from oauth2 module
- extend tests for OAuth2 detection and config retrieval

## Testing
- `cargo test -p integrations --no-run` *(fails: could not compile `db`)*

------
https://chatgpt.com/codex/tasks/task_e_68445ab92ad0832081f3ca842a11914b