### PR TITLE
fix: CSP for data URI images

### DIFF
--- a/crates/k8s-operator/envoy/envoy.yaml
+++ b/crates/k8s-operator/envoy/envoy.yaml
@@ -40,7 +40,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
               inline_code: |
                 function envoy_on_response(response_handle)
-                    csp = "media-src blob:; default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; connect-src 'self'";
+                    csp = "media-src blob:; default-src 'none'; script-src 'self'; img-src 'self' data:; style-src 'self'; connect-src 'self'";
                     response_handle:headers():add("Content-Security-Policy", csp);
                     response_handle:headers():add("X-Frame-Options", "deny");
                     response_handle:headers():add("X-XSS-Protection", "1; mode=block");


### PR DESCRIPTION
## Summary
- adjust CSP headers in Envoy config to allow base64 data URI images

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68481963858483208158bc01913e1ea0