### PR TITLE
Add usage report cron job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5010,6 +5010,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "110352d4e9076c67839003c7788d8604e24dcded13e0b375af3efaa8cf468517"
 
 [[package]]
+name = "usage-report"
+version = "0.1.0"
+dependencies = [
+ "db",
+ "serde_json",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/k8s-operator/config/usage-report-cron.yaml
+++ b/crates/k8s-operator/config/usage-report-cron.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: usage-report
+spec:
+  schedule: "0 0 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: usage-report
+            image: ghcr.io/bionic-gpt/usage-report:latest
+            env:
+            - name: APP_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: database-urls
+                  key: application-url
+            - name: HOSTNAME_URL
+              value: $HOSTNAME_URL
+            - name: IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/crates/usage-report/Cargo.toml
+++ b/crates/usage-report/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "usage-report"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "usage-report"
+path = "main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+db = { path = "../db" }
+tokio-postgres = { version = "0.7", features = ["with-time-0_3", "with-serde_json-1"] }
+serde_json = "1"

--- a/crates/usage-report/main.rs
+++ b/crates/usage-report/main.rs
@@ -1,0 +1,64 @@
+use db::create_pool;
+use serde_json::json;
+use tokio_postgres::Row;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let database_url = std::env::var("APP_DATABASE_URL")?;
+    let hostname_url = std::env::var("HOSTNAME_URL").unwrap_or_default();
+    let ip_address = std::env::var("IP_ADDRESS").unwrap_or_default();
+
+    let pool = create_pool(&database_url);
+    let client = pool.get().await?;
+
+    let user_count: i64 = client
+        .query_one("SELECT COUNT(id) FROM users", &[])
+        .await?
+        .get(0);
+
+    let assistant_count: i64 = client
+        .query_one(
+            "SELECT COUNT(id) FROM prompts WHERE prompt_type = 'Assistant'",
+            &[],
+        )
+        .await?
+        .get(0);
+
+    let tokens_prompt: i64 = client
+        .query_one(
+            "SELECT COALESCE(SUM(tokens),0) FROM token_usage_metrics WHERE type = 'Prompt' AND created_at >= NOW() - INTERVAL '30 days'",
+            &[],
+        )
+        .await?
+        .get(0);
+
+    let tokens_completion: i64 = client
+        .query_one(
+            "SELECT COALESCE(SUM(tokens),0) FROM token_usage_metrics WHERE type = 'Completion' AND created_at >= NOW() - INTERVAL '30 days'",
+            &[],
+        )
+        .await?
+        .get(0);
+
+    let days_since_first_registration: i64 = client
+        .query_one(
+            "SELECT EXTRACT(DAY FROM current_timestamp - MIN(created_at))::int FROM users",
+            &[],
+        )
+        .await?
+        .get(0);
+
+    let report = json!({
+        "hostname_url": hostname_url,
+        "ip_address": ip_address,
+        "user_count": user_count,
+        "assistant_count": assistant_count,
+        "tokens_prompt_last_month": tokens_prompt,
+        "tokens_completion_last_month": tokens_completion,
+        "days_since_first_registration": days_since_first_registration
+    });
+
+    println!("{}", serde_json::to_string_pretty(&report)?);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- create new `usage-report` binary crate for monthly metrics
- add Kubernetes CronJob template
- install the cron job during setup

## Testing
- `cargo fmt --all`
- `cargo check -p usage-report` *(fails: called `Option::unwrap()` on a `None` value)*

------
https://chatgpt.com/codex/tasks/task_e_684ae8f1afc08320ba29190829393a60