### PR TITLE
Refactor integration connection handling

### DIFF
--- a/crates/web-pages/my_assistants/connection_modal.rs
+++ b/crates/web-pages/my_assistants/connection_modal.rs
@@ -1,14 +1,12 @@
-use crate::my_assistants::integrations::{AvailableConnections, IntegrationWithAuthInfo};
+use crate::my_assistants::integrations::IntegrationWithAuthInfo;
 use daisy_rsx::*;
 use dioxus::prelude::*;
-use std::collections::HashMap;
 
 #[component]
 pub fn ConnectionModal(
     team_id: i32,
     prompt_id: i32,
     integration_info: IntegrationWithAuthInfo,
-    available_connections: HashMap<i32, AvailableConnections>,
 ) -> Element {
     let integration = &integration_info.integration;
     let modal_id = format!("add-modal-{}", integration.id);
@@ -36,7 +34,7 @@ pub fn ConnectionModal(
                             label: "Please select an API Key",
                             label_class: "mt-4",
                             help_text: "This is the API key setup in the integration screen",
-                            {available_connections.get(&integration_info.integration.id).unwrap().api_key_connections.iter().map(|connection| rsx!(
+                            {integration_info.api_key_connections.iter().map(|connection| rsx!(
                                 SelectOption {
                                     value: "{connection.id}",
                                     "{connection.id}"
@@ -49,7 +47,7 @@ pub fn ConnectionModal(
                             label: "Please select an Oauth2 connectiony",
                             label_class: "mt-4",
                             help_text: "This is the Oauth2 key setup in the integration screen",
-                            {available_connections.get(&integration_info.integration.id).unwrap().oauth2_connections.iter().map(|connection| rsx!(
+                            {integration_info.oauth2_connections.iter().map(|connection| rsx!(
                                 SelectOption {
                                     value: "{connection.id}",
                                     "{connection.id}"

--- a/crates/web-pages/my_assistants/integrations.rs
+++ b/crates/web-pages/my_assistants/integrations.rs
@@ -6,7 +6,6 @@ use db::authz::Rbac;
 use db::{ApiKeyConnection, Integration, Oauth2Connection};
 use dioxus::prelude::*;
 use serde::Deserialize;
-use std::collections::HashMap;
 use validator::Validate;
 
 #[derive(Deserialize, Validate, Default, Debug)]
@@ -14,20 +13,12 @@ pub struct IntegrationForm {
     pub prompt_id: i32,
     pub prompt_name: String,
     pub selected_integration_ids: Vec<i32>,
-    pub integration_connections: HashMap<i32, ConnectionSelection>,
     #[serde(skip)]
     pub error: Option<String>,
     #[serde(skip)]
     pub integrations: Vec<IntegrationWithAuthInfo>,
-    #[serde(skip)]
-    pub available_connections: HashMap<i32, AvailableConnections>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct ConnectionSelection {
-    pub api_connection_id: Option<i32>,
-    pub oauth2_connection_id: Option<i32>,
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntegrationWithAuthInfo {
@@ -35,13 +26,10 @@ pub struct IntegrationWithAuthInfo {
     pub requires_api_key: bool,
     pub requires_oauth2: bool,
     pub has_connections: bool,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct AvailableConnections {
     pub api_key_connections: Vec<ApiKeyConnection>,
     pub oauth2_connections: Vec<Oauth2Connection>,
 }
+
 
 pub fn page(team_id: i32, rbac: Rbac, form: IntegrationForm) -> String {
     let page = rsx! {
@@ -178,7 +166,6 @@ pub fn page(team_id: i32, rbac: Rbac, form: IntegrationForm) -> String {
                                                             team_id: team_id,
                                                             prompt_id: form.prompt_id,
                                                             integration_info: integration_info.clone(),
-                                                            available_connections: form.available_connections.clone(),
                                                         }
                                                     }
                                                 }

--- a/crates/web-pages/routes.rs
+++ b/crates/web-pages/routes.rs
@@ -239,12 +239,6 @@ pub mod prompts {
         pub prompt_id: i32,
     }
 
-    #[derive(TypedPath, Deserialize)]
-    #[typed_path("/app/team/{team_id}/assistant/{prompt_id}/integrations/update")]
-    pub struct UpdateIntegrations {
-        pub team_id: i32,
-        pub prompt_id: i32,
-    }
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/app/team/{team_id}/assistant/{prompt_id}/integrations/add/{integration_id}")]

--- a/crates/web-server/handlers/my_assistants/integrations.rs
+++ b/crates/web-server/handlers/my_assistants/integrations.rs
@@ -2,22 +2,12 @@ use crate::{CustomError, Jwt};
 use axum::response::Html;
 use axum::{extract::Extension, response::IntoResponse};
 use axum_extra::extract::Form;
-use db::{authz, queries, Pool, Transaction};
+use db::{authz, queries, Pool};
 use serde::Deserialize;
-use std::collections::HashMap;
-use validator::Validate;
 use web_pages::{
     my_assistants,
-    routes::prompts::{AddIntegration, ManageIntegrations, RemoveIntegration, UpdateIntegrations},
+    routes::prompts::{AddIntegration, ManageIntegrations, RemoveIntegration},
 };
-
-#[derive(Deserialize, Validate, Default, Debug)]
-pub struct IntegrationUpdateForm {
-    #[serde(default)]
-    pub integrations: Vec<i32>,
-    #[serde(default)]
-    pub integration_connections: HashMap<String, my_assistants::integrations::ConnectionSelection>,
-}
 
 fn analyze_integration_auth(integration: &db::Integration) -> Result<(bool, bool), CustomError> {
     if let Some(definition) = &integration.definition {
@@ -33,62 +23,7 @@ fn analyze_integration_auth(integration: &db::Integration) -> Result<(bool, bool
     }
 }
 
-async fn update_integrations_with_connections(
-    transaction: &Transaction<'_>,
-    prompt_id: i32,
-    integrations: Vec<i32>,
-    integration_connections: HashMap<String, my_assistants::integrations::ConnectionSelection>,
-) -> Result<(), CustomError> {
-    for integration_id in integrations {
-        let connection_key = integration_id.to_string();
-        let connection = integration_connections.get(&connection_key);
 
-        queries::prompt_integrations::insert_prompt_integration_with_connection()
-            .bind(
-                transaction,
-                &prompt_id,
-                &integration_id,
-                &connection.and_then(|c| c.api_connection_id),
-                &connection.and_then(|c| c.oauth2_connection_id),
-            )
-            .await?;
-    }
-    Ok(())
-}
-
-pub async fn update_integrations_action(
-    UpdateIntegrations { team_id, prompt_id }: UpdateIntegrations,
-    current_user: Jwt,
-    Extension(pool): Extension<Pool>,
-    Form(form): Form<IntegrationUpdateForm>,
-) -> Result<impl IntoResponse, CustomError> {
-    let mut client = pool.get().await?;
-    let transaction = client.transaction().await?;
-
-    let _rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
-
-    // Delete existing integration connections
-    queries::prompt_integrations::delete_prompt_integrations()
-        .bind(&transaction, &prompt_id)
-        .await?;
-
-    // Add new integration connections with connection info
-    update_integrations_with_connections(
-        &transaction,
-        prompt_id,
-        form.integrations,
-        form.integration_connections,
-    )
-    .await?;
-
-    transaction.commit().await?;
-
-    Ok(crate::layout::redirect_and_snackbar(
-        &web_pages::routes::prompts::MyAssistants { team_id }.to_string(),
-        "Integration connections updated successfully",
-    )
-    .into_response())
-}
 
 pub async fn manage_integrations(
     ManageIntegrations { team_id, prompt_id }: ManageIntegrations,
@@ -108,8 +43,6 @@ pub async fn manage_integrations(
     // Analyze each integration for auth requirements
     let mut integrations_with_auth: Vec<my_assistants::integrations::IntegrationWithAuthInfo> =
         Vec::new();
-    let mut available_connections: HashMap<i32, my_assistants::integrations::AvailableConnections> =
-        HashMap::new();
 
     for integration in integrations {
         let (requires_api_key, requires_oauth2) = analyze_integration_auth(&integration)?;
@@ -135,19 +68,13 @@ pub async fn manage_integrations(
 
             let has_connections = !api_connections.is_empty() || !oauth2_connections.is_empty();
 
-            available_connections.insert(
-                integration.id,
-                my_assistants::integrations::AvailableConnections {
-                    api_key_connections: api_connections,
-                    oauth2_connections,
-                },
-            );
-
             integrations_with_auth.push(my_assistants::integrations::IntegrationWithAuthInfo {
                 integration,
                 requires_api_key,
                 requires_oauth2,
                 has_connections,
+                api_key_connections: api_connections,
+                oauth2_connections,
             });
         } else {
             integrations_with_auth.push(my_assistants::integrations::IntegrationWithAuthInfo {
@@ -155,6 +82,8 @@ pub async fn manage_integrations(
                 requires_api_key: false,
                 requires_oauth2: false,
                 has_connections: true, // No auth required, so always "available"
+                api_key_connections: Vec::new(),
+                oauth2_connections: Vec::new(),
             });
         }
     }
@@ -170,21 +99,10 @@ pub async fn manage_integrations(
 
     tracing::debug!("Finished get_prompt_integrations_with_connections");
 
-    let mut integration_connections: HashMap<
-        i32,
-        my_assistants::integrations::ConnectionSelection,
-    > = HashMap::new();
     let mut selected_integration_ids: Vec<i32> = Vec::new();
 
     for existing in existing_connections {
         selected_integration_ids.push(existing.integration_id);
-        integration_connections.insert(
-            existing.integration_id,
-            my_assistants::integrations::ConnectionSelection {
-                api_connection_id: existing.api_connection_id,
-                oauth2_connection_id: existing.oauth2_connection_id,
-            },
-        );
     }
 
     let prompt = queries::prompts::prompt()
@@ -197,8 +115,6 @@ pub async fn manage_integrations(
         prompt_name: prompt.name,
         integrations: integrations_with_auth,
         selected_integration_ids,
-        integration_connections,
-        available_connections,
         error: None,
     };
 

--- a/crates/web-server/handlers/my_assistants/mod.rs
+++ b/crates/web-server/handlers/my_assistants/mod.rs
@@ -15,7 +15,6 @@ pub fn routes() -> Router {
         // Actions
         .typed_post(assistant_actions::upsert)
         .typed_post(datasets::update_datasets_action)
-        .typed_post(integrations::update_integrations_action)
         .typed_post(integrations::add_integration_action)
         .typed_post(integrations::remove_integration_action)
 }


### PR DESCRIPTION
## Summary
- extend integration info to include API key and OAuth2 connection lists
- simplify manage integrations logic and remove update route
- update UI to use integration info directly

## Testing
- `cargo check` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684bcbc37390832091e6530ec31ae911