### PR TITLE
Add cancel buttons to modals

### DIFF
--- a/crates/web-pages/audit_trail/filter.rs
+++ b/crates/web-pages/audit_trail/filter.rs
@@ -79,6 +79,12 @@ pub fn FilterDrawer(team_users: Vec<Member>, reset_search: bool, submit_action: 
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Apply Filter"

--- a/crates/web-pages/console/tools_modal.rs
+++ b/crates/web-pages/console/tools_modal.rs
@@ -42,6 +42,12 @@ pub fn ToolsModal(
 
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Save"

--- a/crates/web-pages/history/form.rs
+++ b/crates/web-pages/history/form.rs
@@ -28,6 +28,12 @@ pub fn Form(team_id: i32) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Run Search"

--- a/crates/web-pages/integrations/api_key_form.rs
+++ b/crates/web-pages/integrations/api_key_form.rs
@@ -44,6 +44,12 @@ pub fn ApiKeyForm(team_id: i32, integration_id: i32, integration_name: String) -
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Save API Key"

--- a/crates/web-pages/logout_form.rs
+++ b/crates/web-pages/logout_form.rs
@@ -35,6 +35,12 @@ pub fn LogoutForm() -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Error,
                             "Logout"

--- a/crates/web-pages/pipelines/key_drawer.rs
+++ b/crates/web-pages/pipelines/key_drawer.rs
@@ -42,6 +42,12 @@ pub fn KeyDrawer(datasets: Vec<Dataset>, team_id: i32) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Create Pipeline"

--- a/crates/web-pages/rate_limits/form.rs
+++ b/crates/web-pages/rate_limits/form.rs
@@ -51,6 +51,12 @@ pub fn Form(team_id: i32, models: Vec<Model>) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Create Limit"

--- a/crates/web-pages/team/invitation_form.rs
+++ b/crates/web-pages/team/invitation_form.rs
@@ -63,6 +63,12 @@ pub fn InvitationForm(submit_action: String) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Send Invitation"

--- a/crates/web-pages/team/team_name_form.rs
+++ b/crates/web-pages/team/team_name_form.rs
@@ -29,6 +29,12 @@ pub fn TeamNameForm(submit_action: String) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Set Team Name"

--- a/crates/web-pages/teams/accept_invitation.rs
+++ b/crates/web-pages/teams/accept_invitation.rs
@@ -36,6 +36,12 @@ pub fn AcceptInvite(invite: db::InviteSummary, team_id: i32) -> Element {
                     }
                     ModalAction {
                         Button {
+                            class: "cancel-modal",
+                            button_scheme: ButtonScheme::Warning,
+                            button_size: ButtonSize::Small,
+                            "Cancel"
+                        }
+                        Button {
                             button_type: ButtonType::Submit,
                             button_scheme: ButtonScheme::Primary,
                             "Accept Invitation"

--- a/crates/web-pages/teams/index.rs
+++ b/crates/web-pages/teams/index.rs
@@ -234,6 +234,12 @@ pub fn page(
                         }
                         ModalAction {
                             Button {
+                                class: "cancel-modal",
+                                button_scheme: ButtonScheme::Warning,
+                                button_size: ButtonSize::Small,
+                                "Cancel"
+                            }
+                            Button {
                                 button_type: ButtonType::Submit,
                                 button_scheme: ButtonScheme::Primary,
                                 "Create Team"


### PR DESCRIPTION
## Summary
- insert a cancel button into every modal

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: Option::unwrap() on a None value)*

------
https://chatgpt.com/codex/tasks/task_e_684d19d5ccb08320a48fa80207443550