### PR TITLE
Replace raw file inputs with FileInput component

### DIFF
--- a/crates/web-pages/documents/upload.rs
+++ b/crates/web-pages/documents/upload.rs
@@ -17,8 +17,7 @@ pub fn Upload(upload_action: String) -> Element {
                         "Upload a file into this dataset"
                     }
 
-                    input {
-                        "type": "file",
+                    FileInput {
                         name: "payload",
                         multiple: true
                     }

--- a/crates/web-pages/my_assistants/upsert.rs
+++ b/crates/web-pages/my_assistants/upsert.rs
@@ -238,11 +238,9 @@ pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
                                     class: "text-sm text-gray-500 mb-3",
                                     "Choose an image that represents your assistant. Recommended size: 48x48 pixels."
                                 }
-                                input {
-                                    "type": "file",
+                                FileInput {
                                     name: "image_icon",
                                     accept: "image/*",
-                                    class: "block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- use the `FileInput` component provided by `daisy_rsx`
- remove unused styling classes from the assistant form

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(failed: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684d36e2883c83208a82b3e23ddf53a1