### PR TITLE
Refactor models index to card layout

### DIFF
--- a/crates/web-pages/models/index.rs
+++ b/crates/web-pages/models/index.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::model_card::ModelCard;
 use crate::app_layout::{Layout, SideBar};
 use crate::ConfirmModal;
 use assets::files::*;
@@ -12,11 +13,6 @@ pub fn page(
     rbac: Rbac,
     models_with_capabilities: Vec<(ModelWithPrompt, bool, bool, bool)>,
 ) -> String {
-    // Extract models for components that don't need capabilities
-    let models: Vec<ModelWithPrompt> = models_with_capabilities
-        .iter()
-        .map(|(model, _, _, _)| model.clone())
-        .collect();
     let page = rsx! {
         Layout {
             section_class: "p-4",
@@ -35,9 +31,40 @@ pub fn page(
                 }
             ),
 
-            super::model_table::ModelTable {
-                models: models.clone(),
-                team_id: team_id
+            div {
+                class: "p-4 max-w-3xl w-full mx-auto",
+                h1 {
+                    class: "text-xl font-semibold mb-4",
+                    "Models"
+                }
+                if models_with_capabilities.is_empty() {
+                    div {
+                        class: "text-center py-12",
+                        p {
+                            class: "text-gray-500 mb-4",
+                            "You haven't added any models yet."
+                        }
+                        Button {
+                            button_type: ButtonType::Link,
+                            href: crate::routes::models::New { team_id }.to_string(),
+                            button_scheme: ButtonScheme::Primary,
+                            "Create Your First Model"
+                        }
+                    }
+                } else {
+                    div {
+                        class: "space-y-2",
+                        for (model, fc, vis, tool) in &models_with_capabilities {
+                            ModelCard {
+                                team_id,
+                                model: model.clone(),
+                                has_function_calling: *fc,
+                                has_vision: *vis,
+                                has_tool_use: *tool
+                            }
+                        }
+                    }
+                }
             }
 
             for (item, _, _, _) in &models_with_capabilities {

--- a/crates/web-pages/models/mod.rs
+++ b/crates/web-pages/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod index;
+pub mod model_card;
 pub mod model_table;
 pub mod model_type;
 pub mod upsert;

--- a/crates/web-pages/models/model_card.rs
+++ b/crates/web-pages/models/model_card.rs
@@ -1,0 +1,83 @@
+#![allow(non_snake_case)]
+use daisy_rsx::*;
+use db::queries::models::ModelWithPrompt;
+use dioxus::prelude::*;
+
+#[component]
+pub fn ModelCard(
+    team_id: i32,
+    model: ModelWithPrompt,
+    has_function_calling: bool,
+    has_vision: bool,
+    has_tool_use: bool,
+) -> Element {
+    let display_name = if model.display_name.is_empty() {
+        model.name.clone()
+    } else {
+        model.display_name.clone()
+    };
+    let description: String = model
+        .description
+        .chars()
+        .filter(|&c| c != '\n' && c != '\t' && c != '\r')
+        .collect();
+
+    rsx!(
+        Card {
+            class: "p-3 mt-5 flex flex-row justify-between",
+            div {
+                class: "flex flex-row",
+                Avatar { avatar_size: AvatarSize::Medium, avatar_type: AvatarType::User }
+                div {
+                    class: "ml-4 text-sm flex flex-col justify-center flex-1 min-w-0",
+                    h2 { class: "font-semibold text-base mb-1", "{display_name}" }
+                    if !description.is_empty() {
+                        p { class: "text-sm text-base-content/70 truncate mb-2", "{description}" }
+                    }
+                    div { class: "flex items-center gap-2 text-xs text-gray-500", super::model_type::Model { model_type: model.model_type } }
+                    div {
+                        class: "flex gap-2 mt-1 text-xs",
+                        if has_function_calling { span { class: "badge badge-ghost", "Functions" } }
+                        if has_vision { span { class: "badge badge-ghost", "Vision" } }
+                        if has_tool_use { span { class: "badge badge-ghost", "Tools" } }
+                    }
+                }
+            }
+            div {
+                class: "flex flex-row gap-5",
+                div {
+                    class: "flex flex-col justify-center text-center",
+                    div { "{model.tpm_limit}" }
+                    div { class: "text-base-content/70", "TPM" }
+                }
+                div {
+                    class: "flex flex-col justify-center text-center",
+                    div { "{model.rpm_limit}" }
+                    div { class: "text-base-content/70", "RPM" }
+                }
+                div {
+                    class: "flex flex-col justify-center text-center",
+                    div { "{model.context_size}" }
+                    div { class: "text-base-content/70", "Context" }
+                }
+                div {
+                    class: "flex flex-col justify-center ml-4 gap-2",
+                    DropDown {
+                        direction: Direction::Bottom,
+                        button_text: "...",
+                        DropDownLink {
+                            href: crate::routes::models::Edit{team_id, id: model.id}.to_string(),
+                            "Edit"
+                        }
+                        DropDownLink {
+                            popover_target: format!("delete-trigger-{}-{}", model.id, team_id),
+                            href: "#",
+                            target: "_top",
+                            "Delete"
+                        }
+                    }
+                }
+            }
+        }
+    )
+}


### PR DESCRIPTION
## Summary
- add `ModelCard` component for summarizing model info
- list model cards in models index page
- include the new module in `models` mod

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: called `Option::unwrap()` on a `None` value)*

------
https://chatgpt.com/codex/tasks/task_e_684d507760ac83209b453020306c5949