### PR TITLE
Add provider_url to OAuth clients

### DIFF
--- a/crates/db/migrations/20250613120100_add_provider_url_to_oauth_clients.sql
+++ b/crates/db/migrations/20250613120100_add_provider_url_to_oauth_clients.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE oauth_clients ADD COLUMN provider_url TEXT;
+
+-- migrate:down
+ALTER TABLE oauth_clients DROP COLUMN provider_url;

--- a/crates/db/queries/oauth_clients.sql
+++ b/crates/db/queries/oauth_clients.sql
@@ -6,8 +6,9 @@ SELECT
     client_id,
     client_secret,
     provider,
+    provider_url,
     created_at
-FROM 
+FROM
     oauth_clients
 ORDER BY provider, created_at DESC;
 
@@ -17,22 +18,38 @@ SELECT
     client_id,
     client_secret,
     provider,
+    provider_url,
     created_at
-FROM 
+FROM
     oauth_clients
 WHERE
     provider = :provider;
+
+--! oauth_client_by_provider_url : OauthClient
+SELECT
+    id,
+    client_id,
+    client_secret,
+    provider,
+    provider_url,
+    created_at
+FROM
+    oauth_clients
+WHERE
+    provider_url = :provider_url;
 
 --! insert_oauth_client
 INSERT INTO oauth_clients (
     client_id,
     client_secret,
-    provider
+    provider,
+    provider_url
 )
 VALUES(
     :client_id,
     :client_secret,
-    :provider
+    :provider,
+    :provider_url
 )
 RETURNING id;
 

--- a/crates/web-pages/oauth_clients/upsert.rs
+++ b/crates/web-pages/oauth_clients/upsert.rs
@@ -14,6 +14,8 @@ pub struct OauthClientForm {
     pub client_secret: String,
     #[validate(length(min = 1, message = "Provider is required"))]
     pub provider: String,
+    #[validate(length(min = 1, message = "Provider URL is required"))]
+    pub provider_url: String,
     #[serde(skip)]
     pub error: Option<String>,
 }
@@ -66,6 +68,16 @@ pub fn page(team_id: i32, rbac: Rbac, oauth_client: OauthClientForm) -> String {
                             help_text: "The OAuth provider name (e.g., google, github, microsoft)",
                             placeholder: "e.g., google, github, microsoft",
                             value: "{oauth_client.provider}",
+                            required: true
+                        }
+
+                        Input {
+                            input_type: InputType::Text,
+                            name: "provider_url",
+                            label: "Provider URL",
+                            help_text: "The OAuth provider authorization URL",
+                            placeholder: "https://accounts.google.com/o/oauth2/v2/auth",
+                            value: "{oauth_client.provider_url}",
                             required: true
                         }
 

--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -50,8 +50,8 @@ pub async fn connect_loader(
     let oauth2_config = get_oauth2_config_from_integration(&integration)?;
 
     // Load OAuth client credentials from the database
-    let oauth_client = queries::oauth_clients::oauth_client_by_provider()
-        .bind(&transaction, &integration.name)
+    let oauth_client = queries::oauth_clients::oauth_client_by_provider_url()
+        .bind(&transaction, &oauth2_config.authorization_url)
         .one()
         .await?;
 
@@ -141,8 +141,8 @@ pub async fn oauth2_callback(
         .one()
         .await?;
     let oauth2_config = get_oauth2_config_from_integration(&integration)?;
-    let oauth_client = queries::oauth_clients::oauth_client_by_provider()
-        .bind(&transaction, &integration.name)
+    let oauth_client = queries::oauth_clients::oauth_client_by_provider_url()
+        .bind(&transaction, &oauth2_config.authorization_url)
         .one()
         .await?;
 

--- a/crates/web-server/handlers/oauth_clients.rs
+++ b/crates/web-server/handlers/oauth_clients.rs
@@ -97,6 +97,8 @@ pub struct OauthClientForm {
     pub client_secret: String,
     #[validate(length(min = 1, message = "Provider is required"))]
     pub provider: String,
+    #[validate(length(min = 1, message = "Provider URL is required"))]
+    pub provider_url: String,
 }
 
 pub async fn create_action(
@@ -121,6 +123,7 @@ pub async fn create_action(
                     &oauth_client_form.client_id,
                     &oauth_client_form.client_secret,
                     &oauth_client_form.provider,
+                    &oauth_client_form.provider_url,
                 )
                 .one()
                 .await?;
@@ -138,6 +141,7 @@ pub async fn create_action(
                 client_id: oauth_client_form.client_id,
                 client_secret: oauth_client_form.client_secret,
                 provider: oauth_client_form.provider,
+                provider_url: oauth_client_form.provider_url,
                 error: Some("Please check the form for errors".to_string()),
             };
             let html = web_pages::oauth_clients::upsert::page(team_id, rbac, oauth_client);


### PR DESCRIPTION
## Summary
- add migration to support `provider_url` on OAuth clients
- include `provider_url` in OAuth client queries
- record provider URL in forms and handlers
- look up OAuth credentials by `provider_url`

## Testing
- `cargo check` *(fails: `build-script-build` for `db` could not find `cornucopia`)*

------
https://chatgpt.com/codex/tasks/task_e_684d44b27bec8320aaa137a261d5c64e