### PR TITLE
Add basic licence enforcement

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -16,7 +16,7 @@ tokio-postgres = { version = "0.7", features = [
 cornucopia_async = { version = "0", features = ["with-serde_json-1"] }
 deadpool-postgres = { version = "0", features = ["serde"] }
 postgres-types = { version = "0", features = ["derive"] }
-time = { version = "0", default-features = false,  features = ["formatting"] }
+time = { version = "0", default-features = false,  features = ["formatting", "serde"] }
 pgvector = { version = "0.3", features = ["postgres"] }
 
 serde = { version = "1", features = ["derive"] }

--- a/crates/db/authz.rs
+++ b/crates/db/authz.rs
@@ -51,6 +51,13 @@ pub async fn get_permissions(
         .all()
         .await?;
 
+    let user_count: i64 = queries::users::count_users()
+        .bind(transaction)
+        .one()
+        .await?;
+    let licence = crate::Licence::from_env();
+    let unlicensed = user_count as usize > licence.user_count;
+
     let rbac = Rbac {
         permissions,
         user_id,
@@ -58,6 +65,7 @@ pub async fn get_permissions(
         first_name,
         last_name,
         is_sys_admin: system_admin,
+        unlicensed,
     };
 
     Ok(rbac)
@@ -153,6 +161,7 @@ pub struct Rbac {
     pub is_sys_admin: bool,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
+    pub unlicensed: bool,
 }
 
 impl Rbac {

--- a/crates/db/lib.rs
+++ b/crates/db/lib.rs
@@ -1,6 +1,7 @@
 pub mod authz;
 pub mod customer_keys;
 pub mod vector_search;
+pub mod licence;
 
 use std::str::FromStr;
 
@@ -33,6 +34,7 @@ pub use types::public::{
     ModelType, Permission, PromptType, Role, TokenUsageType, Visibility,
 };
 pub use vector_search::{get_related_context, RelatedContext};
+pub use licence::Licence;
 
 pub fn create_pool(database_url: &str) -> deadpool_postgres::Pool {
     let config = tokio_postgres::Config::from_str(database_url).unwrap();

--- a/crates/db/licence.rs
+++ b/crates/db/licence.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use time::{Date, Month};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Licence {
+    pub user_count: usize,
+    pub end_date: Date,
+    pub signature: String,
+}
+
+impl Default for Licence {
+    fn default() -> Self {
+        Self {
+            user_count: 2,
+            end_date: Date::from_calendar_date(9999, Month::December, 31).unwrap(),
+            signature: String::new(),
+        }
+    }
+}
+
+impl Licence {
+    pub fn from_env() -> Self {
+        if let Ok(json) = std::env::var("LICENCE") {
+            serde_json::from_str(&json).unwrap_or_default()
+        } else {
+            Self::default()
+        }
+    }
+}

--- a/crates/web-pages/app_layout.rs
+++ b/crates/web-pages/app_layout.rs
@@ -216,7 +216,8 @@ pub fn Layout(props: LayoutProps) -> Element {
                     email: props.rbac.email.clone(),
                     first_name: props.rbac.first_name.clone().unwrap_or("".to_string()),
                     last_name: props.rbac.last_name.clone().unwrap_or("".to_string()),
-                    team_id: props.team_id
+                    team_id: props.team_id,
+                    unlicensed: props.rbac.unlicensed,
                 }
             ),
             {props.children}

--- a/crates/web-pages/profile_popup.rs
+++ b/crates/web-pages/profile_popup.rs
@@ -4,7 +4,13 @@ use daisy_rsx::*;
 use dioxus::prelude::*;
 
 #[component]
-pub fn ProfilePopup(email: String, first_name: String, last_name: String, team_id: i32) -> Element {
+pub fn ProfilePopup(
+    email: String,
+    first_name: String,
+    last_name: String,
+    team_id: i32,
+    unlicensed: bool,
+) -> Element {
     let user_name_or_email = if !first_name.is_empty() || !last_name.is_empty() {
         format!("{} {}", first_name, last_name)
     } else {
@@ -12,6 +18,13 @@ pub fn ProfilePopup(email: String, first_name: String, last_name: String, team_i
     };
 
     rsx! {
+        if unlicensed {
+            Alert {
+                alert_color: AlertColor::Error,
+                class: "mb-2",
+                "This is an unlicenced version of bionic"
+            }
+        }
         DropDown {
             direction: Direction::Top,
             button_text: "{user_name_or_email}",


### PR DESCRIPTION
## Summary
- add Licence struct and default values
- surface licence status in Rbac
- show unlicenced warning in sidebar footer

## Testing
- `cargo test --workspace --quiet` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684d644e053083208cd9594858550f11