### PR TITLE
Switch to DaisyUI colors

### DIFF
--- a/crates/web-pages/charts.rs
+++ b/crates/web-pages/charts.rs
@@ -42,7 +42,7 @@ pub fn TokenUsageChart(data: Vec<DailyTokenUsage>) -> Element {
                             y: "{200 - (prompt_tokens * 180 / max_tokens)}",
                             width: "40",
                             height: "{prompt_tokens * 180 / max_tokens}",
-                            fill: "#3b82f6",
+                            fill: "hsl(var(--p))",
                             class: "hover:opacity-80 cursor-pointer"
                         }
                         // Stacked bar for completion tokens (top)
@@ -51,7 +51,7 @@ pub fn TokenUsageChart(data: Vec<DailyTokenUsage>) -> Element {
                             y: "{200 - ((prompt_tokens + completion_tokens) * 180 / max_tokens)}",
                             width: "40",
                             height: "{completion_tokens * 180 / max_tokens}",
-                            fill: "#10b981",
+                            fill: "hsl(var(--su))",
                             class: "hover:opacity-80 cursor-pointer"
                         }
                         text {
@@ -87,7 +87,7 @@ pub fn ApiRequestChart(data: Vec<DailyApiRequests>) -> Element {
                             y: "{200 - (day_data.request_count * 180 / max_requests)}",
                             width: "40",
                             height: "{day_data.request_count * 180 / max_requests}",
-                            fill: "#6366f1",
+                            fill: "hsl(var(--p))",
                             class: "hover:opacity-80 cursor-pointer"
                         }
                         text {
@@ -120,7 +120,7 @@ pub fn TokenUsageChartCard(data: Vec<DailyTokenUsage>, title: String) -> Element
                     div {
                         class: "flex items-center",
                         div {
-                            class: "w-4 h-4 bg-blue-500 mr-2"
+                            class: "w-4 h-4 bg-primary mr-2"
                         }
                         span {
                             class: "text-sm",
@@ -130,7 +130,7 @@ pub fn TokenUsageChartCard(data: Vec<DailyTokenUsage>, title: String) -> Element
                     div {
                         class: "flex items-center",
                         div {
-                            class: "w-4 h-4 bg-green-500 mr-2"
+                            class: "w-4 h-4 bg-success mr-2"
                         }
                         span {
                             class: "text-sm",

--- a/crates/web-pages/console/history_drawer.rs
+++ b/crates/web-pages/console/history_drawer.rs
@@ -19,7 +19,7 @@ pub fn HistoryDrawer(trigger_id: String, team_id: i32, history: Vec<History>) ->
                         li {
                             class: "w-full overflow-hidden truncate",
                             a {
-                                class: "block p-2 hover:bg-gray-100 rounded",
+                                class: "block p-2 hover:bg-base-200 rounded",
                                 href: crate::routes::console::Conversation{team_id, conversation_id: history.id}.to_string(),
                                 {history.summary.clone()}
                             }

--- a/crates/web-pages/console/prompt_drawer.rs
+++ b/crates/web-pages/console/prompt_drawer.rs
@@ -22,7 +22,7 @@ pub fn PromptDrawer(
                 }
                 if rbac.can_view_system_prompt() {
                     pre {
-                        class: "json bg-gray-100 p-4 rounded overflow-auto max-h-96",
+                        class: "json bg-base-200 p-4 rounded overflow-auto max-h-96",
                         "{prompt}"
                     }
                 } else {

--- a/crates/web-pages/integrations/connections_section.rs
+++ b/crates/web-pages/integrations/connections_section.rs
@@ -60,9 +60,9 @@ pub fn ConnectionsSection(
 
                     if api_key_connections.is_empty() {
                         div {
-                            class: "bg-gray-50 border border-gray-200 rounded-lg p-4",
+                            class: "bg-base-100 border border-base-300 rounded-lg p-4",
                             p {
-                                class: "text-gray-500 text-center",
+                                class: "text-base-content/70 text-center",
                                 "No API key connections configured"
                             }
                         }
@@ -92,9 +92,9 @@ pub fn ConnectionsSection(
 
                     if oauth2_connections.is_empty() {
                         div {
-                            class: "bg-gray-50 border border-gray-200 rounded-lg p-4",
+                            class: "bg-base-100 border border-base-300 rounded-lg p-4",
                             p {
-                                class: "text-gray-500 text-center",
+                                class: "text-base-content/70 text-center",
                                 "No OAuth2 connections configured"
                             }
                         }

--- a/crates/web-pages/integrations/parameter_renderer.rs
+++ b/crates/web-pages/integrations/parameter_renderer.rs
@@ -9,9 +9,9 @@ pub fn render_parameter(
     depth: usize,
 ) -> Element {
     let indent_class = match depth {
-        0 => "border-l-2 border-blue-200 pl-3 py-2",
-        1 => "border-l-2 border-green-200 pl-6 py-1 ml-3",
-        _ => "border-l-2 border-gray-200 pl-6 py-1 ml-6",
+        0 => "border-l-2 border-primary pl-3 py-2",
+        1 => "border-l-2 border-success pl-6 py-1 ml-3",
+        _ => "border-l-2 border-base-300 pl-6 py-1 ml-6",
     };
 
     let param_type = param_schema
@@ -41,16 +41,16 @@ pub fn render_parameter(
 
                 // Type and format
                 span {
-                    class: "bg-blue-100 text-blue-700 text-xs px-2 py-0.5 rounded",
+                    class: "bg-primary/20 text-primary text-xs px-2 py-0.5 rounded",
                     "{param_type}"
                     if let Some(fmt) = format {
-                        span { class: "text-blue-500", ", {fmt}" }
+                        span { class: "text-primary", ", {fmt}" }
                     }
                 }
 
                 // Required/Optional badge
                 span {
-                    class: if is_required { "bg-red-100 text-red-700" } else { "bg-gray-100 text-gray-700" },
+                    class: if is_required { "bg-error/20 text-error" } else { "bg-base-200 text-base-content" },
                     class: "text-xs px-2 py-0.5 rounded",
                     if is_required { "required" } else { "optional" }
                 }
@@ -58,11 +58,11 @@ pub fn render_parameter(
                 // Example value
                 if let Some(ex) = example {
                     span {
-                        class: "text-xs text-gray-500",
+                        class: "text-xs text-base-content/70",
                         "Example: "
                     }
                     code {
-                        class: "bg-gray-100 px-1 py-0.5 rounded text-xs",
+                        class: "bg-base-200 px-1 py-0.5 rounded text-xs",
                         "{ex}"
                     }
                 }
@@ -71,7 +71,7 @@ pub fn render_parameter(
             // Optional: description below in smaller font
             if let Some(desc) = description {
                 p {
-                    class: "text-xs text-gray-500 ml-1",
+                    class: "text-xs text-base-content/70 ml-1",
                     "{desc}"
                 }
             }

--- a/crates/web-pages/snackbar.rs
+++ b/crates/web-pages/snackbar.rs
@@ -6,13 +6,13 @@ pub fn Snackbar() -> Element {
     rsx! {
         div {
             id: "snackbar",
-            class: "fixed bottom-0 left-1/2 transform -translate-x-1/2 bg-gray-800/90 text-white flex justify-between items-center rounded-md mb-8 min-w-[288px] max-w-[568px] p-4 transition-transform duration-500 ease-out translate-y-full opacity-0",
+            class: "fixed bottom-0 left-1/2 transform -translate-x-1/2 bg-neutral/90 text-white flex justify-between items-center rounded-md mb-8 min-w-[288px] max-w-[568px] p-4 transition-transform duration-500 ease-out translate-y-full opacity-0",
             // Starts with translate-y-full and opacity-0 to be hidden
             p {
                 class: "m-0 p-0"
             }
             button {
-                class: "action bg-inherit border-none text-green-500 uppercase ml-6 p-0 min-w-min cursor-pointer",
+                class: "action bg-inherit border-none text-success uppercase ml-6 p-0 min-w-min cursor-pointer",
                 "DISMISS"
             }
         }

--- a/crates/web-pages/workflows/view.rs
+++ b/crates/web-pages/workflows/view.rs
@@ -43,7 +43,7 @@ pub fn view(team_id: i32, rbac: Rbac, workflow: Option<Workflow>) -> String {
                                 }
                             }
                             p {
-                                class: "text-gray-600 mb-4",
+                                class: "text-base-content/70 mb-4",
                                 "{workflow.description}"
                             }
                         }
@@ -61,7 +61,7 @@ pub fn view(team_id: i32, rbac: Rbac, workflow: Option<Workflow>) -> String {
                             "Instructions"
                         }
                         textarea {
-                            class: "w-full h-32 p-4 border border-gray-300 rounded-lg resize-none bg-gray-50",
+                            class: "w-full h-32 p-4 border border-base-300 rounded-lg resize-none bg-base-100",
                             readonly: true,
                             "Connect to linked in and get anyone who has set their job to an AI related field in the last few days"
                         }
@@ -147,25 +147,25 @@ pub fn view(team_id: i32, rbac: Rbac, workflow: Option<Workflow>) -> String {
                         }
                         div {
                             class: "grid grid-cols-1 md:grid-cols-2 gap-4",
-                            div {
-                                class: "bg-gray-50 p-4 rounded-lg",
+                              div {
+                                  class: "bg-base-100 p-4 rounded-lg",
                                 h4 {
-                                    class: "font-medium text-gray-700 mb-2",
+                                      class: "font-medium text-base-content mb-2",
                                     "Trigger Type"
                                 }
                                 p {
-                                    class: "text-gray-900",
+                                      class: "text-base-content",
                                     "{workflow.trigger_type}"
                                 }
                             }
-                            div {
-                                class: "bg-gray-50 p-4 rounded-lg",
+                              div {
+                                  class: "bg-base-100 p-4 rounded-lg",
                                 h4 {
-                                    class: "font-medium text-gray-700 mb-2",
+                                      class: "font-medium text-base-content mb-2",
                                     "Category"
                                 }
                                 p {
-                                    class: "text-gray-900",
+                                      class: "text-base-content",
                                     "{workflow.category}"
                                 }
                             }
@@ -175,11 +175,11 @@ pub fn view(team_id: i32, rbac: Rbac, workflow: Option<Workflow>) -> String {
                     // Back to workflows link
                     div {
                         class: "mt-8 pt-6 border-t",
-                        a {
-                            href: crate::routes::workflows::Index { team_id }.to_string(),
-                            class: "inline-flex items-center text-blue-600 hover:text-blue-800 font-medium",
-                            "← Back to Workflows"
-                        }
+                          a {
+                              href: crate::routes::workflows::Index { team_id }.to_string(),
+                              class: "inline-flex items-center text-primary hover:text-primary-focus font-medium",
+                              "← Back to Workflows"
+                          }
                     }
                 }
             } else {
@@ -187,18 +187,18 @@ pub fn view(team_id: i32, rbac: Rbac, workflow: Option<Workflow>) -> String {
                 div {
                     class: "text-center py-12",
                     h2 {
-                        class: "text-xl font-semibold text-gray-900 mb-2",
+                        class: "text-xl font-semibold text-base-content mb-2",
                         "Workflow Not Found"
                     }
                     p {
-                        class: "text-gray-600 mb-6",
+                        class: "text-base-content/70 mb-6",
                         "The requested workflow could not be found."
                     }
-                    a {
-                        href: crate::routes::workflows::Index { team_id }.to_string(),
-                        class: "inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium",
-                        "← Back to Workflows"
-                    }
+                      a {
+                          href: crate::routes::workflows::Index { team_id }.to_string(),
+                          class: "inline-flex items-center px-4 py-2 bg-primary text-primary-content rounded-lg hover:bg-primary-focus font-medium",
+                          "← Back to Workflows"
+                      }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace tailwind colours in parameter renderer with DaisyUI tokens
- use DaisyUI colours for integration connection sections
- update snackbar styling to DaisyUI
- switch workflow view colours to DaisyUI tokens
- update charts and other UI components

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684e63c5428883208da2b5c50cab91a5