### PR TITLE
Refactor team pages to card layout

### DIFF
--- a/crates/web-pages/team/member_card.rs
+++ b/crates/web-pages/team/member_card.rs
@@ -1,0 +1,108 @@
+#![allow(non_snake_case)]
+use daisy_rsx::*;
+use db::authz::Rbac;
+use db::{Invitation, Member};
+use dioxus::prelude::*;
+
+#[component]
+pub fn MemberCard(member: Member, rbac: Rbac) -> Element {
+    let name = match (&member.first_name, &member.last_name) {
+        (Some(f), Some(l)) => format!("{} {}", f, l),
+        _ => member.email.clone(),
+    };
+    rsx!(
+        Card {
+            class: "p-3 flex flex-row justify-between",
+            div {
+                class: "flex flex-row items-center",
+                Avatar {
+                    avatar_type: avatar::AvatarType::User,
+                    name: "{name}"
+                }
+                div {
+                    class: "ml-4 flex flex-col",
+                    h2 {
+                        class: "font-semibold text-base mb-1",
+                        "{name}"
+                    }
+                    Label {
+                        label_role: LabelRole::Success,
+                        class: "w-fit",
+                        "Active"
+                    }
+                }
+            }
+            div {
+                class: "flex items-center gap-2",
+                for role in member.roles.clone() {
+                    crate::team::team_role::Role { role }
+                }
+            }
+            if rbac.can_make_invitations() && rbac.email != member.email {
+                div {
+                    class: "flex flex-col justify-center ml-4",
+                    DropDown {
+                        direction: Direction::Left,
+                        button_text: "...",
+                        DropDownLink {
+                            popover_target: format!("remove-member-trigger-{}-{}", member.id, member.team_id),
+                            href: "#",
+                            target: "_top",
+                            "Remove User From Team"
+                        }
+                    }
+                }
+            }
+        }
+    )
+}
+
+#[component]
+pub fn InvitePendingCard(invite: Invitation, rbac: Rbac) -> Element {
+    let name = format!("{} {}", invite.first_name, invite.last_name);
+    rsx!(
+        Card {
+            class: "p-3 flex flex-row justify-between",
+            div {
+                class: "flex flex-row items-center",
+                Avatar {
+                    avatar_type: avatar::AvatarType::User,
+                    name: "{invite.first_name}"
+                }
+                div {
+                    class: "ml-4 flex flex-col",
+                    h2 {
+                        class: "font-semibold text-base mb-1",
+                        "{name}"
+                    }
+                    Label {
+                        label_role: LabelRole::Highlight,
+                        class: "w-fit",
+                        "Invite Pending"
+                    }
+                }
+            }
+            div {
+                class: "flex items-center gap-2",
+                for role in invite.roles.clone() {
+                    crate::team::team_role::Role { role }
+                }
+            }
+            if rbac.can_make_invitations() {
+                div {
+                    class: "flex flex-col justify-center ml-4",
+                    DropDown {
+                        direction: Direction::Left,
+                        button_text: "...",
+                        DropDownLink {
+                            popover_target: format!("remove-invite-trigger-{}-{}", invite.id, invite.team_id),
+                            href: "#",
+                            target: "_top",
+                            "Delete Invite"
+                        }
+                    }
+                }
+            }
+        }
+    )
+}

--- a/crates/web-pages/team/members.rs
+++ b/crates/web-pages/team/members.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::member_card::{InvitePendingCard, MemberCard};
 use crate::app_layout::{Layout, SideBar};
 use crate::ConfirmModal;
 use assets::files::*;
@@ -76,123 +77,13 @@ pub fn page(
                     }
                 }
                 CardBody {
-                    table {
-                        class: "table table-sm",
-                        thead {
-                            th { "Name or Email" }
-                            th { "Status" }
-                            th {
-                                class: "max-sm:hidden",
-                                "Special Privelages"
-                            }
-                            if rbac.can_make_invitations() {
-                                th {
-                                    class: "text-right",
-                                    "Action"
-                                }
-                            }
+                    div {
+                        class: "space-y-2",
+                        for member in &members {
+                            MemberCard { member: member.clone(), rbac: rbac.clone() }
                         }
-                        tbody {
-                            for member in &members {
-                                tr {
-                                    td {
-                                        if let (Some(first_name), Some(last_name)) = (&member.first_name, &member.last_name) {
-                                            Avatar {
-                                                name: "{first_name}",
-                                                avatar_type: avatar::AvatarType::User
-                                            }
-                                            span {
-                                                class: "ml-2",
-                                                "{first_name} {last_name}"
-                                            }
-                                        } else {
-                                            Avatar {
-                                                name: "{member.email}",
-                                                avatar_type: avatar::AvatarType::User
-                                            }
-                                            span {
-                                                class: "ml-2",
-                                                "{member.email}"
-                                            }
-                                        }
-                                    }
-                                    td {
-                                        Label {
-                                            label_role: LabelRole::Success,
-                                            "Active"
-                                        }
-                                    }
-                                    td {
-                                        class: "max-sm:hidden",
-                                        for role in member.roles.clone() {
-                                            super::team_role::Role {
-                                                role: role
-                                            }
-                                        }
-                                    }
-                                    if rbac.can_make_invitations() && rbac.email != member.email {
-                                        td {
-                                            class: "text-right",
-                                            DropDown {
-                                                direction: Direction::Left,
-                                                button_text: "...",
-                                                DropDownLink {
-                                                    popover_target: format!("remove-member-trigger-{}-{}",
-                                                        member.id, member.team_id),
-                                                    href: "#",
-                                                    target: "_top",
-                                                    "Remove User From Team"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            for invite in &invites {
-                                tr {
-                                    td {
-                                            Avatar {
-                                                name: "{invite.first_name}",
-                                                avatar_type: avatar::AvatarType::User
-                                            }
-                                            span {
-                                                class: "ml-2",
-                                                "{invite.first_name} {invite.last_name}"
-                                            }
-                                    }
-                                    td {
-                                        Label {
-                                            label_role: LabelRole::Highlight,
-                                            "Invite Pending"
-                                        }
-                                    }
-                                    td {
-                                        for role in invite.roles.clone() {
-                                            super::team_role::Role {
-                                                role
-                                            }
-                                        }
-                                    }
-
-                                    if rbac.can_make_invitations() {
-                                        td {
-                                            class: "text-right",
-                                            DropDown {
-                                                direction: Direction::Left,
-                                                button_text: "...",
-                                                DropDownLink {
-                                                    popover_target: format!("remove-invite-trigger-{}-{}",
-                                                        invite.id, invite.team_id),
-                                                    href: "#",
-                                                    target: "_top",
-                                                    "Delete Invite"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                        for invite in &invites {
+                            InvitePendingCard { invite: invite.clone(), rbac: rbac.clone() }
                         }
                     }
                 }

--- a/crates/web-pages/team/mod.rs
+++ b/crates/web-pages/team/mod.rs
@@ -1,4 +1,5 @@
 pub mod invitation_form;
+pub mod member_card;
 pub mod members;
 pub mod remove_warning;
 pub mod team_name_form;

--- a/crates/web-pages/teams/index.rs
+++ b/crates/web-pages/teams/index.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::{invite_card::InviteCard, team_card::TeamCard};
 use crate::app_layout::{Layout, SideBar};
 use crate::ConfirmModal;
 use assets::files::button_plus_svg;
@@ -36,107 +37,14 @@ pub fn page(
                     title: "Teams"
                 }
                 CardBody {
-                    table {
-                        class: "table table-sm",
-                        thead {
-                            th { "Team" }
-                            th { "Team Creator" }
-                            th {
-                                class: "text-right",
-                                "Action"
-                            }
-                        }
-                        tbody {
-                            for team in &teams {
-
-                                if let Some(name) = &team.team_name {
-                                    tr {
-                                        td {
-                                            Avatar {
-                                                name: "{name}",
-                                                avatar_type: avatar::AvatarType::Team
-                                            }
-                                            span {
-                                                class: "ml-2 mr-2",
-                                                "{name}"
-                                            }
-                                            if team.id != team_id {
-                                                a {
-                                                    "data-turbo-frame": "_top",
-                                                    href: crate::routes::team::Index{ team_id: team.id }.to_string(),
-                                                    "(Switch to this Team)"
-                                                }
-                                            }
-                                        }
-                                        td {
-                                            strong {
-                                                "{team.team_owner}"
-                                            }
-                                        }
-                                        if team.team_owner == current_user_email && teams.len() > 1 {
-                                            td {
-                                                class: "text-right",
-                                                DropDown {
-                                                    direction: Direction::Left,
-                                                    button_text: "...",
-                                                    DropDownLink {
-                                                        popover_target: format!("delete-trigger-{}", team.id),
-                                                        href: "#",
-                                                        target: "_top",
-                                                        "Delete Team"
-                                                    }
-                                                }
-                                            }
-                                        } else {
-                                            td {
-                                                class: "text-right",
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    tr {
-                                        td {
-                                            Avatar {
-                                                avatar_type: avatar::AvatarType::Team
-                                            }
-                                            span {
-                                                class: "ml-2 mr-2",
-                                                "Name Not Set"
-                                            }
-                                            if team.id != team_id {
-                                                a {
-                                                    "data-turbo-frame": "_top",
-                                                    href: crate::routes::team::Index{ team_id: team.id }.to_string(),
-                                                    "(Switch to this Team)"
-                                                }
-                                            }
-                                        }
-                                        td {
-                                            strong {
-                                                "{team.team_owner}"
-                                            }
-                                        }
-                                        if team.team_owner == current_user_email && teams.len() > 1 {
-                                            td {
-                                                class: "text-right",
-                                                DropDown {
-                                                    direction: Direction::Left,
-                                                    button_text: "...",
-                                                    DropDownLink {
-                                                        popover_target: format!("delete-trigger-{}", team.id),
-                                                        href: "#",
-                                                        target: "_top",
-                                                        "Delete Team"
-                                                    }
-                                                }
-                                            }
-                                        } else {
-                                            td {
-                                                class: "text-right",
-                                            }
-                                        }
-                                    }
-                                }
+                    div {
+                        class: "space-y-2",
+                        for team in &teams {
+                            TeamCard {
+                                team: team.clone(),
+                                current_team_id: team_id,
+                                teams_len: teams.len(),
+                                current_user_email: current_user_email.clone(),
                             }
                         }
                     }
@@ -150,40 +58,10 @@ pub fn page(
                     title: "You have invitations to join the following teams"
                 }
                 CardBody {
-                    table {
-                        class: "table table-sm",
-                        thead {
-                            th { "Team" }
-                            th {
-                                "Team Creator"
-                            }
-                            th {
-                                class: "text-right",
-                                "Action"
-                            }
-                        }
-                        tbody {
-                            for invite in &invites {
-                                td {
-                                    "{invite.team_name}"
-                                }
-                                td {
-                                    "{invite.created_by}"
-                                }
-                                td {
-                                    class: "text-right",
-                                    DropDown {
-                                        direction: Direction::Left,
-                                        button_text: "...",
-                                        DropDownLink {
-                                            popover_target: format!("accept-invite-trigger-{}", invite.id),
-                                            href: "#",
-                                            target: "_top",
-                                            "Accept Invite"
-                                        }
-                                    }
-                                }
-                            }
+                    div {
+                        class: "space-y-2",
+                        for invite in &invites {
+                            InviteCard { invite: invite.clone() }
                         }
                     }
                 }

--- a/crates/web-pages/teams/invite_card.rs
+++ b/crates/web-pages/teams/invite_card.rs
@@ -1,0 +1,40 @@
+#![allow(non_snake_case)]
+use daisy_rsx::*;
+use db::InviteSummary;
+use dioxus::prelude::*;
+
+#[component]
+pub fn InviteCard(invite: InviteSummary) -> Element {
+    rsx!(
+        Card {
+            class: "p-3 flex flex-row justify-between",
+            div {
+                class: "flex flex-row items-center",
+                Avatar {
+                    avatar_type: avatar::AvatarType::User,
+                    name: "{invite.first_name}"
+                }
+                div {
+                    class: "ml-4 flex flex-col",
+                    h2 {
+                        class: "font-semibold text-base mb-1",
+                        "{invite.team_name}"
+                    }
+                    p {
+                        class: "text-sm text-base-content/70",
+                        "Invited by {invite.created_by}"
+                    }
+                }
+            }
+            div {
+                class: "flex flex-col justify-center ml-4",
+                Button {
+                    button_scheme: ButtonScheme::Primary,
+                    button_size: ButtonSize::Small,
+                    popover_target: format!("accept-invite-trigger-{}", invite.id),
+                    "Accept Invite"
+                }
+            }
+        }
+    )
+}

--- a/crates/web-pages/teams/mod.rs
+++ b/crates/web-pages/teams/mod.rs
@@ -1,2 +1,4 @@
 pub mod accept_invitation;
 pub mod index;
+pub mod invite_card;
+pub mod team_card;

--- a/crates/web-pages/teams/team_card.rs
+++ b/crates/web-pages/teams/team_card.rs
@@ -1,0 +1,66 @@
+#![allow(non_snake_case)]
+use daisy_rsx::*;
+use db::TeamOwner;
+use dioxus::prelude::*;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct TeamCardProps {
+    pub team: TeamOwner,
+    pub current_team_id: i32,
+    pub teams_len: usize,
+    pub current_user_email: String,
+}
+
+#[component]
+pub fn TeamCard(props: TeamCardProps) -> Element {
+    let name = props
+        .team
+        .team_name
+        .clone()
+        .unwrap_or_else(|| "Name Not Set".to_string());
+    rsx!(
+        Card {
+            class: "p-3 flex flex-row justify-between",
+            div {
+                class: "flex flex-row items-center",
+                Avatar {
+                    avatar_type: avatar::AvatarType::Team,
+                    name: "{name}"
+                }
+                div {
+                    class: "ml-4 flex flex-col",
+                    h2 {
+                        class: "font-semibold text-base mb-1",
+                        "{name}"
+                    }
+                    p {
+                        class: "text-sm text-base-content/70",
+                        "{props.team.team_owner}"
+                    }
+                    if props.team.id != props.current_team_id {
+                        a {
+                            href: crate::routes::team::Index{ team_id: props.team.id }.to_string(),
+                            class: "text-xs text-primary",
+                            "Switch to this Team"
+                        }
+                    }
+                }
+            }
+            if props.team.team_owner == props.current_user_email && props.teams_len > 1 {
+                div {
+                    class: "flex flex-col justify-center ml-4",
+                    DropDown {
+                        direction: Direction::Left,
+                        button_text: "...",
+                        DropDownLink {
+                            popover_target: format!("delete-trigger-{}", props.team.id),
+                            href: "#",
+                            target: "_top",
+                            "Delete Team"
+                        }
+                    }
+                }
+            }
+        }
+    )
+}


### PR DESCRIPTION
## Summary
- create reusable `TeamCard`, `InviteCard`, `MemberCard` and `InvitePendingCard` components
- refactor `teams/index.rs` and `team/members.rs` to use card layouts instead of tables

## Testing
- `cargo fmt`
- `DATABASE_URL=postgresql://postgres:testpassword@localhost:5432/postgres?sslmode=disable cargo check` *(fails: called `Result::unwrap()` on an `Err` value)*

------
https://chatgpt.com/codex/tasks/task_e_684e904c4d888320b5b629d235388bd5