### PR TITLE
Fix OAuth client secret encryption

### DIFF
--- a/crates/db/queries/oauth_clients.sql
+++ b/crates/db/queries/oauth_clients.sql
@@ -4,7 +4,7 @@
 SELECT
     id,
     client_id,
-    client_secret,
+    decrypt_text(client_secret) as client_secret,
     provider,
     provider_url,
     created_at
@@ -16,7 +16,7 @@ ORDER BY provider, created_at DESC;
 SELECT
     id,
     client_id,
-    client_secret,
+    decrypt_text(client_secret) as client_secret,
     provider,
     provider_url,
     created_at
@@ -29,7 +29,7 @@ WHERE
 SELECT
     id,
     client_id,
-    client_secret,
+    decrypt_text(client_secret) as client_secret,
     provider,
     provider_url,
     created_at
@@ -47,7 +47,7 @@ INSERT INTO oauth_clients (
 )
 VALUES(
     :client_id,
-    :client_secret,
+    encrypt_text(:client_secret),
     :provider,
     :provider_url
 )


### PR DESCRIPTION
## Summary
- encrypt `client_secret` value when inserting OAuth clients
- decrypt `client_secret` in queries returning OAuth clients

## Testing
- `cargo test` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_684fad460d148320a178634dd0db5b29