### PR TITLE
Display integration connection counts

### DIFF
--- a/crates/web-pages/integrations/index.rs
+++ b/crates/web-pages/integrations/index.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::integration_cards::IntegrationSummary;
 use crate::app_layout::{Layout, SideBar};
 use crate::routes;
 use assets::files::*;
@@ -7,7 +8,7 @@ use db::authz::Rbac;
 use dioxus::prelude::*;
 use integrations::BionicOpenAPI;
 
-pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<(BionicOpenAPI, i32)>) -> String {
+pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<IntegrationSummary>) -> String {
     let page = rsx! {
         Layout {
             section_class: "p-4",


### PR DESCRIPTION
## Summary
- show OAuth2 or API key connection counts for each integration
- collect connection counts in integration loader

## Testing
- `cargo fmt --all`
- `cargo test --quiet` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_684fadf86aac8320ba0612c368a182ec