### PR TITLE
Fix migration script to set defaults for tokens

### DIFF
--- a/crates/db/migrations/20250606081200_migrate_data_and_update_api_chats.sql
+++ b/crates/db/migrations/20250606081200_migrate_data_and_update_api_chats.sql
@@ -62,17 +62,23 @@ INSERT INTO api_chats (
     role,
     status,
     created_at,
-    updated_at
+    updated_at,
+    tokens_sent,
+    tokens_received,
+    time_taken_ms
 )
-SELECT 
+SELECT
     api_key_id,
     '' AS prompt,
     response,
     'Assistant'::chat_role,
     status,
     created_at,
-    updated_at
-FROM api_chats 
+    updated_at,
+    0,
+    0,
+    0
+FROM api_chats
 WHERE response IS NOT NULL AND response != '';
 
 -- Drop the inference_metrics view first since it depends on token columns


### PR DESCRIPTION
## Summary
- ensure tokens columns are set when inserting assistant responses

## Testing
- `just test` *(fails: thread 'main' panicked at crates/db/build.rs:22:46, called `Option::unwrap()` on a `None` value)*

------
https://chatgpt.com/codex/tasks/task_e_684fd31cd3d883209075d6fc5d724fe8