### PR TITLE
Add visibility enforcement for integrations

### DIFF
--- a/crates/db/migrations/20250616000000_integrations_visibility.sql
+++ b/crates/db/migrations/20250616000000_integrations_visibility.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE integrations ADD COLUMN visibility visibility NOT NULL DEFAULT 'Company';
+ALTER TABLE integrations ALTER COLUMN visibility DROP DEFAULT;
+
+-- migrate:down
+ALTER TABLE integrations DROP COLUMN visibility;

--- a/crates/db/queries/integrations.sql
+++ b/crates/db/queries/integrations.sql
@@ -5,11 +5,26 @@ SELECT
     id,
     name,
     integration_type,
+    visibility,
     definition,
     created_at,
     updated_at
-FROM 
-    integrations
+FROM
+    integrations i
+WHERE
+    (
+        (
+            i.visibility = 'Team'
+            AND i.team_id IN (
+                SELECT team_id
+                FROM team_users
+                WHERE user_id = current_app_user()
+            )
+            AND i.team_id = :team_id
+        )
+        OR (i.visibility = 'Company')
+        OR (i.visibility = 'Private' AND i.created_by = current_app_user())
+    )
 ORDER BY updated_at;
 
 --! integration : Integration
@@ -17,13 +32,27 @@ SELECT
     id,
     name,
     integration_type,
+    visibility,
     definition,
     created_at,
     updated_at
-FROM 
-    integrations
+FROM
+    integrations i
 WHERE
-    id = :model_id
+    i.id = :model_id
+    AND (
+        (
+            i.visibility = 'Team'
+            AND i.team_id IN (
+                SELECT team_id
+                FROM team_users
+                WHERE user_id = current_app_user()
+            )
+            AND i.team_id = :team_id
+        )
+        OR (i.visibility = 'Company')
+        OR (i.visibility = 'Private' AND i.created_by = current_app_user())
+    )
 ORDER BY updated_at;
 
 
@@ -31,22 +60,25 @@ ORDER BY updated_at;
 INSERT INTO integrations (
     name,
     definition,
-    integration_type
+    integration_type,
+    visibility
 )
 VALUES(
     :name,
     :definition,
-    :integration_type
+    :integration_type,
+    :visibility
 )
 RETURNING id;
 
 --! update(definition?)
-UPDATE 
-    integrations 
-SET 
+UPDATE
+    integrations
+SET
     name = :name,
     definition = :definition,
-    integration_type = :integration_type
+    integration_type = :integration_type,
+    visibility = :visibility
 WHERE
     id = :id;
 

--- a/crates/web-pages/integrations/upsert.rs
+++ b/crates/web-pages/integrations/upsert.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 use crate::app_layout::{Layout, SideBar};
 use daisy_rsx::*;
-use db::authz::Rbac;
+use db::{authz::Rbac, Visibility};
 use dioxus::prelude::*;
 use serde::Deserialize;
 use validator::Validate;
@@ -11,6 +11,7 @@ pub struct IntegrationForm {
     pub id: Option<i32>,
     #[validate(length(min = 1, message = "OpenAPI specification is required"))]
     pub openapi_spec: String,
+    pub visibility: String,
     #[serde(skip)]
     pub error: Option<String>,
 }
@@ -69,6 +70,33 @@ pub fn page(team_id: i32, rbac: Rbac, integration: IntegrationForm) -> String {
                             p {
                                 class: "mt-1 text-sm text-gray-500",
                                 "Paste your complete OpenAPI 3.0+ specification in JSON format"
+                            }
+                        }
+
+                        div {
+                            class: "mt-4",
+                            Select {
+                                name: "visibility",
+                                label: "Visibility",
+                                help_text: "Who can use this integration",
+                                value: "{integration.visibility}",
+                                SelectOption {
+                                    value: "{crate::visibility_to_string(db::Visibility::Private)}",
+                                    selected_value: "{integration.visibility}",
+                                    {crate::visibility_to_string(db::Visibility::Private)}
+                                }
+                                SelectOption {
+                                    value: "{crate::visibility_to_string(db::Visibility::Team)}",
+                                    selected_value: "{integration.visibility}",
+                                    {crate::visibility_to_string(db::Visibility::Team)}
+                                }
+                                if rbac.can_make_assistant_public() {
+                                    SelectOption {
+                                        value: "{crate::visibility_to_string(db::Visibility::Company)}",
+                                        selected_value: "{integration.visibility}",
+                                        {crate::visibility_to_string(db::Visibility::Company)}
+                                    }
+                                }
                             }
                         }
 

--- a/crates/web-server/handlers/assistants/loaders.rs
+++ b/crates/web-server/handlers/assistants/loaders.rs
@@ -51,7 +51,7 @@ pub async fn new_assistant_loader(
         .await?;
 
     let _integrations = queries::integrations::integrations()
-        .bind(&transaction)
+        .bind(&transaction, &team_id)
         .all()
         .await?;
 
@@ -109,7 +109,7 @@ pub async fn edit_assistant_loader(
         .await?;
 
     let _integrations = queries::integrations::integrations()
-        .bind(&transaction)
+        .bind(&transaction, &team_id)
         .all()
         .await?;
 

--- a/crates/web-server/handlers/integrations/actions.rs
+++ b/crates/web-server/handlers/integrations/actions.rs
@@ -2,10 +2,11 @@ use crate::{CustomError, Jwt};
 use axum::extract::Extension;
 use axum::response::{Html, IntoResponse};
 use axum::Form;
-use db::{authz, queries, Pool};
+use db::{authz, queries, Pool, Visibility};
 use validator::Validate;
 use web_pages::integrations::upsert::IntegrationForm;
 use web_pages::routes::integrations::{Delete, Edit, New};
+use web_pages::string_to_visibility;
 
 use super::helpers::parse_openapi_spec;
 
@@ -62,6 +63,7 @@ pub async fn edit_action(
 
     match integration_form.validate() {
         Ok(_) => {
+            let visibility = string_to_visibility(&integration_form.visibility);
             // The form is valid, update the integration
             queries::integrations::update()
                 .bind(
@@ -69,6 +71,7 @@ pub async fn edit_action(
                     &integration_name,
                     &definition, // definition
                     &integration_type,
+                    &visibility,
                     &id,
                 )
                 .await?;
@@ -120,6 +123,7 @@ pub async fn new_action(
 
     match integration_form.validate() {
         Ok(_) => {
+            let visibility = string_to_visibility(&integration_form.visibility);
             // The form is valid, create a new integration
             queries::integrations::insert()
                 .bind(
@@ -127,6 +131,7 @@ pub async fn new_action(
                     &integration_name,
                     &definition, // definition
                     &integration_type,
+                    &visibility,
                 )
                 .one()
                 .await?;

--- a/crates/web-server/handlers/my_assistants/integrations.rs
+++ b/crates/web-server/handlers/my_assistants/integrations.rs
@@ -34,7 +34,7 @@ pub async fn manage_integrations(
     let rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
 
     let integrations = queries::integrations::integrations()
-        .bind(&transaction)
+        .bind(&transaction, &team_id)
         .all()
         .await?;
 

--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -42,7 +42,7 @@ pub async fn connect_loader(
 
     // Get the integration from the database
     let integration = queries::integrations::integration()
-        .bind(&transaction, &integration_id)
+        .bind(&transaction, &integration_id, &team_id)
         .one()
         .await?;
 
@@ -139,7 +139,7 @@ pub async fn oauth2_callback(
 
     // Load OAuth client credentials
     let integration = queries::integrations::integration()
-        .bind(&transaction, &integration_id)
+        .bind(&transaction, &integration_id, &team_id)
         .one()
         .await?;
     let oauth2_config = get_oauth2_config_from_integration(&integration)?;


### PR DESCRIPTION
## Summary
- enforce visibility filters in integrations SQL queries
- allow choosing visibility when creating or editing an integration
- propagate visibility through server handlers

## Testing
- `cargo fmt --all`
- `cargo test --workspace --exclude integration-testing --exclude rag-engine --no-run` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4a9b3b48320a3e81fb99bea1a39