### PR TITLE
Fix duplicate oauth clients

### DIFF
--- a/crates/db/migrations/20250617090000_unique_provider_url_in_oauth_clients.sql
+++ b/crates/db/migrations/20250617090000_unique_provider_url_in_oauth_clients.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+-- Remove duplicate provider_url rows keeping the one with the smallest id
+DELETE FROM oauth_clients a
+USING oauth_clients b
+WHERE a.provider_url = b.provider_url
+  AND a.id > b.id;
+
+ALTER TABLE oauth_clients
+    ADD CONSTRAINT unique_provider_url UNIQUE(provider_url);
+
+-- migrate:down
+ALTER TABLE oauth_clients
+    DROP CONSTRAINT IF EXISTS unique_provider_url;


### PR DESCRIPTION
## Summary
- enforce unique provider_url for OAuth clients
- prevent duplicates on insert
- cleanup duplicates and add uniqueness constraint via migration

## Testing
- `cargo check -p web-server` *(fails: failed to run custom build command)*

------
https://chatgpt.com/codex/tasks/task_e_68516b96dc508320a1a091054c727e5c