### PR TITLE
Add shm volume to selenium pod recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,15 @@ selenium:
         '    image: selenium/standalone-chrome' \
         '    ports:' \
         '    - containerPort: 4444' \
+        '    volumeMounts:' \
+        '    - name: dshm' \
+        '      mountPath: /dev/shm' \
+        '  # Mirrors --shm-size=2g from .devcontainer/docker-compose.yml and CI' \
+        '  volumes:' \
+        '  - name: dshm' \
+        '    emptyDir:' \
+        '      medium: Memory' \
+        '      sizeLimit: 2Gi' \
     | kubectl replace --force -f -
     kubectl wait --for=condition=Ready pod/selenium-chrome -n bionic-gpt --timeout=60s
     kubectl port-forward pod/selenium-chrome 4444:4444 7900:7900 -n bionic-gpt


### PR DESCRIPTION
## Summary
- update selenium recipe with /dev/shm volume
- document that the 2Gi volume mirrors devcontainer and CI

## Testing
- `cargo fmt --all`
- `cargo check -q` *(fails: called `Result::unwrap()` on an `Err` value)*

------
https://chatgpt.com/codex/tasks/task_e_68526a9b6168832084855aefcfae2589