### PR TITLE
Fix missing add button

### DIFF
--- a/crates/web-pages/pipelines/index.rs
+++ b/crates/web-pages/pipelines/index.rs
@@ -22,12 +22,10 @@ pub fn page(
             title: "Document Pipelines",
             header: rsx!(
                 h3 { "Document Pipelines" }
-                if !pipelines.is_empty() {
-                    Button {
-                        popover_target: "create-api-key",
-                        button_scheme: ButtonScheme::Primary,
-                        "New Pipeline"
-                    }
+                Button {
+                    popover_target: "create-api-key",
+                    button_scheme: ButtonScheme::Primary,
+                    "New Pipeline"
                 }
             ),
 


### PR DESCRIPTION
## Summary
- show New Pipeline button even on empty page

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_68539be443f08320aff0f24e2bccb1ad