### PR TITLE
Add Breadcrumbs to headers

### DIFF
--- a/crates/web-pages/api_keys/index.rs
+++ b/crates/web-pages/api_keys/index.rs
@@ -26,7 +26,12 @@ pub fn page(
             rbac: rbac,
             title: "API Keys",
             header: rsx! {
-                h3 { "API Keys" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "API Keys".into(),
+                        href: None
+                    }]
+                }
                 div {
                     class: "flex gap-4",
                     Button {

--- a/crates/web-pages/assistants/conversation.rs
+++ b/crates/web-pages/assistants/conversation.rs
@@ -41,7 +41,12 @@ pub fn page(
             enabled_tools,
             available_tools,
             header: rsx!(
-                h3 { "{prompt.name}" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: prompt.name.clone(),
+                        href: None
+                    }]
+                }
                 if ! chat_history.is_empty() {
                     div {
                         class: "flex flex-row",

--- a/crates/web-pages/audit_trail/index.rs
+++ b/crates/web-pages/audit_trail/index.rs
@@ -24,7 +24,12 @@ pub fn page(
             rbac: rbac,
             title: "Audit Trail",
             header: rsx! {
-                h3 { "Audit Trail" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Audit Trail".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     popover_target: super::filter::DRAW_TRIGGER,
                     button_scheme: ButtonScheme::Neutral,

--- a/crates/web-pages/history/index.rs
+++ b/crates/web-pages/history/index.rs
@@ -18,7 +18,12 @@ pub fn page(rbac: Rbac, team_id: i32, history: Vec<History>) -> String {
             rbac: rbac,
             title: "Chat History",
             header: rsx! {
-                h3 { "Chat History" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Chat History".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     prefix_image_src: "{button_plus_svg.name}",
                     popover_target: "search-history",

--- a/crates/web-pages/history/results.rs
+++ b/crates/web-pages/history/results.rs
@@ -16,7 +16,12 @@ pub fn page(rbac: Rbac, team_id: i32, history: Vec<History>) -> String {
             rbac: rbac,
             title: "Chat History",
             header: rsx!(
-                h3 { "Chat History" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Chat History".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     popover_target: "search-history",
                     button_scheme: ButtonScheme::Primary,

--- a/crates/web-pages/integrations/upsert.rs
+++ b/crates/web-pages/integrations/upsert.rs
@@ -27,7 +27,12 @@ pub fn page(team_id: i32, rbac: Rbac, integration: IntegrationForm) -> String {
             rbac: rbac.clone(),
             title: "Integrations",
             header: rsx!(
-                h3 { "Integrations" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Integrations".into(),
+                        href: None
+                    }]
+                }
             ),
 
             Card {

--- a/crates/web-pages/pipelines/index.rs
+++ b/crates/web-pages/pipelines/index.rs
@@ -21,7 +21,12 @@ pub fn page(
             rbac: rbac,
             title: "Document Pipelines",
             header: rsx!(
-                h3 { "Document Pipelines" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Document Pipelines".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     popover_target: "create-api-key",
                     button_scheme: ButtonScheme::Primary,

--- a/crates/web-pages/profile.rs
+++ b/crates/web-pages/profile.rs
@@ -23,7 +23,12 @@ fn Page(
             team_id: team_id,
             rbac: rbac,
             header: rsx!(
-                h3 { "Your Profile" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Your Profile".into(),
+                        href: None
+                    }]
+                }
             ),
             BlankSlate {
                 heading: "Welcome, {users_name_or_email}",

--- a/crates/web-pages/rate_limits/index.rs
+++ b/crates/web-pages/rate_limits/index.rs
@@ -23,7 +23,12 @@ pub fn page(
             rbac: rbac,
             title: "Rate Limits",
             header: rsx! {
-                h3 { "Rate Limits" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Rate Limits".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     prefix_image_src: "{button_plus_svg.name}",
                     popover_target: "create-limit",

--- a/crates/web-pages/team/members.rs
+++ b/crates/web-pages/team/members.rs
@@ -24,7 +24,12 @@ pub fn page(
             rbac: rbac.clone(),
             title: "Team Members",
             header: rsx!(
-                h3 { "Team Members" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Team Members".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     prefix_image_src: "{button_plus_svg.name}",
                     popover_target: "create-invite-form",

--- a/crates/web-pages/teams/index.rs
+++ b/crates/web-pages/teams/index.rs
@@ -23,7 +23,12 @@ pub fn page(
             rbac: rbac,
             title: "Your Teams",
             header: rsx!(
-                h3 { "Your Teams" }
+                Breadcrumb {
+                    items: vec![BreadcrumbItem {
+                        text: "Your Teams".into(),
+                        href: None
+                    }]
+                }
                 Button {
                     prefix_image_src: "{button_plus_svg.name}",
                     popover_target: "create-new-team",


### PR DESCRIPTION
## Summary
- add Breadcrumb component to various pages missing it

## Testing
- `cargo fmt`
- `cargo check` *(fails: called `Result::unwrap()` on an `Err` value)*
- `cargo test` *(fails: failed to run custom build command)*

------
https://chatgpt.com/codex/tasks/task_e_6853c1e054108320a7c38e3012345f76