### PR TITLE
Add read_document tool

### DIFF
--- a/crates/integrations/Cargo.toml
+++ b/crates/integrations/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = { version = "0.1" }
 oas3 = "0.16.1"
 oauth2 = "5.0.0"
 reqwest = { version = "0", default-features = false, features = ["json", "rustls-tls"] }
+llm-proxy = { path = "../llm-proxy" }
 
 # Used by the web tool to stream responses
 futures-util = "0.3"

--- a/crates/integrations/tool_executor.rs
+++ b/crates/integrations/tool_executor.rs
@@ -98,6 +98,11 @@ pub async fn get_tools(
             conversation_id,
         ),
     ));
+    tools.push(Arc::new(tools::read_document::ReadDocumentTool::new(
+        pool.clone(),
+        sub.clone(),
+        conversation_id,
+    )));
 
     // Get external integration tools
     debug!("Getting external integration tools");

--- a/crates/integrations/tool_registry.rs
+++ b/crates/integrations/tool_registry.rs
@@ -41,10 +41,12 @@ pub fn get_integrations(scope: Option<ToolScope>) -> Vec<IntegrationTool> {
             title: "Tools to retrieve documents and read their contents.".into(),
             definitions: vec![
                 tools::list_documents::get_tool_definition(),
+                tools::read_document::get_tool_definition(),
                 tools::read_document_section::get_tool_definition(),
             ],
             definitions_json: serde_json::to_string_pretty(&vec![
                 tools::list_documents::get_tool_definition(),
+                tools::read_document::get_tool_definition(),
                 tools::read_document_section::get_tool_definition(),
             ])
             .expect("Failed to serialize attachment tools to JSON"),

--- a/crates/integrations/tools/mod.rs
+++ b/crates/integrations/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod list_documents;
 pub mod open_api_tool;
+pub mod read_document;
 pub mod read_document_section;
 pub mod search_context;
 pub mod time_date;

--- a/crates/integrations/tools/read_document.rs
+++ b/crates/integrations/tools/read_document.rs
@@ -1,0 +1,176 @@
+use crate::tool::ToolInterface;
+use async_trait::async_trait;
+use db::Pool;
+use openai_api::{BionicToolDefinition, ChatCompletionFunctionDefinition};
+use rag_engine::unstructured::{document_to_chunks, MetaData, Unstructured};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+struct ReadDocumentParams {
+    file_id: i32,
+    #[serde(default)]
+    section_index: usize,
+}
+
+pub struct ReadDocumentTool {
+    pool: Pool,
+    sub: String,
+    conversation_id: i64,
+}
+
+impl ReadDocumentTool {
+    pub fn new(pool: Pool, sub: String, conversation_id: i64) -> Self {
+        Self {
+            pool,
+            sub,
+            conversation_id,
+        }
+    }
+}
+
+pub fn get_tool_definition() -> BionicToolDefinition {
+    BionicToolDefinition {
+        r#type: "function".to_string(),
+        function: ChatCompletionFunctionDefinition {
+            name: "read_document".to_string(),
+            description: Some(
+                "Read sections from a document attachment respecting the model context size."
+                    .to_string(),
+            ),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "file_id": {"type": "integer", "description": "ID of the attachment"},
+                    "section_index": {"type": "integer", "minimum": 0, "description": "Index of the first section (default 0)"}
+                },
+                "required": ["file_id"]
+            })),
+        },
+    }
+}
+
+fn accumulate_sections(
+    sections: &[Unstructured],
+    start_index: usize,
+    max_tokens: i32,
+) -> (String, usize, bool) {
+    let mut tokens_so_far = 0;
+    let mut text_parts: Vec<String> = Vec::new();
+    let mut end_index = start_index;
+
+    while end_index < sections.len() {
+        let section = &sections[end_index];
+        let section_tokens = llm_proxy::token_count::token_count_from_string(&section.text);
+        if tokens_so_far + section_tokens > max_tokens {
+            break;
+        }
+        tokens_so_far += section_tokens;
+        text_parts.push(section.text.clone());
+        end_index += 1;
+    }
+
+    (
+        text_parts.join("\n\n"),
+        end_index - start_index,
+        end_index < sections.len(),
+    )
+}
+
+#[async_trait]
+impl ToolInterface for ReadDocumentTool {
+    fn get_tool(&self) -> BionicToolDefinition {
+        get_tool_definition()
+    }
+
+    async fn execute(&self, arguments: &str) -> Result<serde_json::Value, serde_json::Value> {
+        let params: ReadDocumentParams = serde_json::from_str(arguments)
+            .map_err(|e| json!({"error": "Invalid parameters", "details": e.to_string()}))?;
+
+        let mut client = self.pool.get().await.map_err(
+            |e| json!({"error": "Failed to get DB connection", "details": e.to_string()}),
+        )?;
+        let transaction = client.transaction().await.map_err(
+            |e| json!({"error": "Failed to start transaction", "details": e.to_string()}),
+        )?;
+
+        db::authz::set_row_level_security_user_id(&transaction, self.sub.clone())
+            .await
+            .map_err(|e| json!({"error": "Failed to set RLS", "details": e.to_string()}))?;
+
+        let context_row = transaction
+            .query_one(
+                "SELECT context_size FROM conversations WHERE id = $1",
+                &[&self.conversation_id],
+            )
+            .await
+            .map_err(
+                |e| json!({"error": "Failed to fetch conversation", "details": e.to_string()}),
+            )?;
+        let context_size: i32 = context_row.get(0);
+
+        let content = db::queries::attachments::get_content()
+            .bind(&transaction, &params.file_id)
+            .one()
+            .await
+            .map_err(
+                |e| json!({"error": "Failed to get attachment content", "details": e.to_string()}),
+            )?;
+
+        let bytes = content.object_data;
+        let config = rag_engine::config::Config::new();
+        let sections = document_to_chunks(
+            bytes,
+            &content.file_name,
+            500,
+            1500,
+            true,
+            &config.unstructured_endpoint,
+        )
+        .await
+        .map_err(|e| json!({"error": "Document processing failed", "details": e.to_string()}))?;
+
+        let start = params.section_index.min(sections.len());
+        let (text, sections_read, has_more) = accumulate_sections(&sections, start, context_size);
+
+        Ok(json!({
+            "text": text,
+            "sections_read": sections_read,
+            "has_more": has_more
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy(text: &str) -> Unstructured {
+        Unstructured {
+            type_of: String::new(),
+            element_id: String::new(),
+            metadata: MetaData {
+                filename: String::new(),
+                filetype: String::new(),
+                page_number: None,
+            },
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_get_read_document_tool() {
+        let tool = get_tool_definition();
+        assert_eq!(tool.function.name, "read_document");
+    }
+
+    #[test]
+    fn test_accumulate_sections_limit() {
+        let sections = vec![dummy("one"), dummy("two three"), dummy("four five six")];
+        let tokens = llm_proxy::token_count::token_count_from_string("one two three");
+        let (text, count, has_more) = accumulate_sections(&sections, 0, tokens);
+        assert_eq!(count, 2);
+        assert!(has_more);
+        assert!(text.contains("one"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `read_document` tool to load attachment sections with token limit
- register the tool and instantiate during execution
- expose module in integrator tools
- depend on llm-proxy for token counting

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: cyclic package dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6853c2ca53388320a3ee28c17c237645