### PR TITLE
Add conversation context size query

### DIFF
--- a/crates/db/lib.rs
+++ b/crates/db/lib.rs
@@ -13,7 +13,7 @@ pub use queries::audit_trail::AuditTrail;
 pub use queries::categories::Category;
 pub use queries::chats::Chat;
 pub use queries::connections::{ApiKeyConnection, Oauth2Connection};
-pub use queries::conversations::Conversation;
+pub use queries::conversations::{Conversation, ConversationContextSize};
 pub use queries::datasets::Dataset;
 pub use queries::document_pipelines::DocumentPipeline;
 pub use queries::history::History;

--- a/crates/db/queries/conversations.sql
+++ b/crates/db/queries/conversations.sql
@@ -57,3 +57,12 @@ WHERE
     c.id = :conversation_id
 AND
     c.user_id = current_app_user();
+--: ConversationContextSize()
+--! conversation_context_size : ConversationContextSize
+SELECT m.context_size
+FROM conversations c
+JOIN prompts p ON c.prompt_id = p.id
+JOIN models m ON p.model_id = m.id
+WHERE c.id = :conversation_id
+  AND c.user_id = current_app_user();
+


### PR DESCRIPTION
## Summary
- extend `conversations.sql` with `conversation_context_size` query
- regenerate Cornucopia structs
- re-export `ConversationContextSize` in `db` crate

## Testing
- `cargo build -p db` *(fails: could not compile `db`)*

------
https://chatgpt.com/codex/tasks/task_e_6853c2d715508320aeb207691a2344ab