### PR TITLE
Fix workflow_run triggers

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   scan:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -11,6 +11,7 @@ on:
 jobs:
 
   integration_testing:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## Summary
- don't trigger container scan or k3s integration tests on cancelled CI runs

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: cyclic package dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6853d09107708320b92cb2e77a0e844f