### PR TITLE
Fix patch command in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,7 @@ chunking-engine-setup:
         -n bionic-gpt
     kubectl patch deployment chunking-engine -n bionic-gpt \
         --type='json' \
-        -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command"}]'y
+        -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command"}]'
 
 expose-chunking-engine:
     kubectl -n bionic-gpt port-forward --address 0.0.0.0 deployment/chunking-engine 8000:8000


### PR DESCRIPTION
## Summary
- correct kubectl patch syntax in `chunking-engine-setup`

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings` *(fails: process didn't exit successfully)*
- `just test` *(fails: build script error for `db` crate)*

------
https://chatgpt.com/codex/tasks/task_e_68553e435cd08320a6214322265e1755