### PR TITLE
Update OAuth2 callback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Try our [Docker Compose](https://bionic-gpt.com/docs/running-locally/docker-comp
 
 follow [our guide](https://bionic-gpt.com/docs/) to running Bionic-GPT in production.
 
+### Configuration
+
+Set the `APP_BASE_URL` environment variable to the public URL of your Bionic server. This value is used when constructing OAuth2 callback URLs.
+
 ## Architecture
 
 

--- a/crates/k8s-operator/src/services/bionic.rs
+++ b/crates/k8s-operator/src/services/bionic.rs
@@ -51,6 +51,10 @@ pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result
             "/oidc/realms/bionic-gpt/protocol/openid-connect/logout"
         }),
         json!({
+            "name": "APP_BASE_URL",
+            "value": spec.hostname_url.clone()
+        }),
+        json!({
             "name":
             INVITE_DOMAIN,
             "valueFrom": {

--- a/crates/web-pages/routes.rs
+++ b/crates/web-pages/routes.rs
@@ -398,11 +398,8 @@ pub mod integrations {
     }
 
     #[derive(TypedPath, Deserialize)]
-    #[typed_path("/app/team/{team_id}/integrations/{integration_id}/oauth2/callback")]
-    pub struct OAuth2Callback {
-        pub team_id: i32,
-        pub integration_id: i32,
-    }
+    #[typed_path("/app/oauth2/callback")]
+    pub struct OAuth2Callback {}
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/app/team/{team_id}/integrations/{integration_id}/configure_api_key")]

--- a/crates/web-server/config.rs
+++ b/crates/web-server/config.rs
@@ -55,6 +55,8 @@ pub struct Config {
     pub saas: bool,
     // Are we using barricade?
     pub enable_barricade: bool,
+    // Public base URL for redirects
+    pub base_url: String,
 }
 
 impl Default for Config {
@@ -90,6 +92,9 @@ impl Config {
 
         let enable_barricade = env::var("ENABLE_BARRICADE").is_ok();
 
+        let base_url =
+            env::var("APP_BASE_URL").unwrap_or_else(|_| "http://localhost:7703".to_string());
+
         let app_database_url = env::var("APP_DATABASE_URL").expect("APP_DATABASE_URL not set");
 
         Config {
@@ -100,6 +105,7 @@ impl Config {
             version,
             saas,
             enable_barricade,
+            base_url,
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow setting `APP_BASE_URL` for configuring public URLs
- redirect OAuth2 flows to the new `/app/oauth2/callback` endpoint
- store team and integration IDs in cookies during OAuth2 flow
- adapt callback handler and route definitions
- document `APP_BASE_URL` in README
- set `APP_BASE_URL` when deploying Bionic via k8s operator

## Testing
- `cargo fmt --all`
- `cargo test --workspace --quiet` *(failed: No such file or directory in db build script)*

------
https://chatgpt.com/codex/tasks/task_e_68553e725430832091ea5d29216204d0