### PR TITLE
Improve OAuth client error alert

### DIFF
--- a/crates/web-pages/integrations/integration_cards.rs
+++ b/crates/web-pages/integrations/integration_cards.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 use daisy_rsx::*;
 use dioxus::prelude::*;
-use integrations::BionicOpenAPI;
+use integrations::{BionicOpenAPI, OAuth2Config};
 
 #[derive(Clone, PartialEq)]
 pub struct IntegrationSummary {
@@ -115,10 +115,9 @@ pub fn IntegrationCards(integrations: Vec<IntegrationSummary>, team_id: i32) -> 
                 }
             }
             if integration.openapi.get_oauth2_config().is_some() && !integration.oauth_client_configured {
-                let oauth_config = integration.openapi.get_oauth2_config().unwrap();
                 MissingOauthClientModal {
                     trigger_id: format!("missing-oauth-client-{}", integration.id),
-                    authorization_url: oauth_config.authorization_url
+                    oauth2_config: integration.openapi.get_oauth2_config()
                 }
             }
         }
@@ -126,7 +125,12 @@ pub fn IntegrationCards(integrations: Vec<IntegrationSummary>, team_id: i32) -> 
 }
 
 #[component]
-fn MissingOauthClientModal(trigger_id: String, authorization_url: String) -> Element {
+fn MissingOauthClientModal(trigger_id: String, oauth2_config: Option<OAuth2Config>) -> Element {
+    let authorization_url = if let Some(oauth2_config) = oauth2_config {
+        oauth2_config.authorization_url
+    } else {
+        "NOT FOUND".to_string()
+    };
     rsx! {
         Modal {
             trigger_id: &trigger_id,

--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -72,11 +72,7 @@ pub async fn connect_loader(
         .map_err(|_| CustomError::FaultySetup("Invalid token endpoint URL".to_string()))?;
 
     // Set up the config for the OAuth2 process using dynamic configuration
-    let redirect_uri = format!(
-        "{}{}",
-        config.base_url,
-        OAuth2Callback {}.to_string()
-    );
+    let redirect_uri = format!("{}{}", config.base_url, OAuth2Callback {});
     tracing::debug!("Redirect URI set to {}", redirect_uri);
     let client = BasicClient::new(client_id)
         .set_client_secret(client_secret)


### PR DESCRIPTION
## Summary
- provide more detail in the OAuth client missing modal

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_685577a5f048832087f8cb7c70b06a55