### PR TITLE
Handle query params in OpenApiTool

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -16,7 +16,7 @@ tokio-postgres = { version = "0.7", features = [
 cornucopia_async = { version = "0", features = ["with-serde_json-1"] }
 deadpool-postgres = { version = "0", features = ["serde"] }
 postgres-types = { version = "0", features = ["derive"] }
-time = { version = "0.3.41", default-features = false,  features = ["formatting", "serde"] }
+time = { version = "0.3.41", default-features = false,  features = ["formatting", "serde", "parsing"] }
 pgvector = { version = "0.3", features = ["postgres"] }
 tracing = { version = "0.1" }
 

--- a/crates/integrations/Cargo.toml
+++ b/crates/integrations/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 async-trait = { version = "0.1" }
 oas3 = "0.16.1"
 oauth2 = "5.0.0"
-reqwest = { version = "0", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0", default-features = false, features = ["json", "rustls-tls", "stream"] }
 
 # Used by the web tool to stream responses
 futures-util = "0.3"

--- a/crates/integrations/tools/open_api_tool.rs
+++ b/crates/integrations/tools/open_api_tool.rs
@@ -117,7 +117,7 @@ impl ToolInterface for OpenApiTool {
             .map_err(|e| crate::json_error("Failed to substitute path parameters", e))?;
 
         // Construct the final URL and append query parameters
-        let mut url = reqwest::Url::parse(&format!("{}{}", self.base_url, path_with_params))
+        let mut url = Url::parse(&format!("{}{}", self.base_url, path_with_params))
             .map_err(|e| crate::json_error("Invalid URL", e))?;
         if let Some(obj) = query_params.as_object() {
             if !obj.is_empty() {
@@ -150,7 +150,7 @@ impl ToolInterface for OpenApiTool {
             .map_err(|e| crate::json_error("Unsupported HTTP method", e))?;
 
         // Build the request
-        let mut request = self.client.request(http_method, &url);
+        let mut request = self.client.request(http_method, url);
         request = self.add_auth_header_if_present(request);
         if has_request_body {
             request = request.json(&request_body_params);


### PR DESCRIPTION
## Summary
- extend parameter separation to return path, query, and body values separately
- append query parameters when building URL
- add unit test for query parameter separation

## Testing
- `cargo test --all --no-run` *(fails: couldn't establish a database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6857b0ff7d848320a03a2e5a68e10242