### PR TITLE
Fix OAuth2 callback URI

### DIFF
--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -72,7 +72,7 @@ pub async fn connect_loader(
         .map_err(|_| CustomError::FaultySetup("Invalid token endpoint URL".to_string()))?;
 
     // Set up the config for the OAuth2 process using dynamic configuration
-    let redirect_uri = format!("{}{}", config.base_url, OAuth2Callback {});
+    let redirect_uri = format!("{}{}", config.base_url, OAuth2Callback {}.to_string());
     tracing::debug!("Redirect URI set to {}", redirect_uri);
     let client = BasicClient::new(client_id)
         .set_client_secret(client_secret)


### PR DESCRIPTION
## Summary
- convert typed path to string when constructing OAuth2 redirect URI

## Testing
- `cargo test --workspace --locked --quiet` *(fails: db build script missing queries)*

------
https://chatgpt.com/codex/tasks/task_e_6857b100904083208aea92188aa35762