### PR TITLE
Fix OAuth2 connection modal

### DIFF
--- a/crates/web-pages/integrations/view.rs
+++ b/crates/web-pages/integrations/view.rs
@@ -17,6 +17,7 @@ pub fn view(
     openapi: BionicOpenAPI,
     api_key_connections: Vec<ApiKeyConnection>,
     oauth2_connections: Vec<Oauth2Connection>,
+    oauth_client_configured: bool,
 ) -> String {
     let page = rsx! {
         Layout {
@@ -61,7 +62,8 @@ pub fn view(
                     rbac,
                     openapi: openapi.clone(),
                     api_key_connections,
-                    oauth2_connections
+                    oauth2_connections,
+                    oauth_client_configured
                 }
 
                 ActionsSection {


### PR DESCRIPTION
## Summary
- handle missing OAuth clients in `ConnectionsSection`
- plumb `oauth_client_configured` through integration view
- compute OAuth client presence in view loader

## Testing
- `cargo check` *(fails: thread 'main' panicked at crates/db/build.rs:36:10: No such file or directory)*
- `cargo fmt --all -- --check` *(fails: rustfmt component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857b4913a7483208b95dfd05ffe520e