### PR TITLE
Move asset build to build.rs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,8 @@ Bionic runs in a `devcontainer` and uses [k3d](https://k3d.io/stable/) to run su
 1. Use `k9s` to check the status of the services.
 1. When all the services are loaded you can check by running `db` you should now have access to the database.
 1. `dbmate up` to create the database tables
-1. Run `wp` to run and watch the Typescript pipeline.
-1. Run `wt` to run and watch the Tailwind pipeline.
-1. Run `wa` to build and watch the Bionic server.
+1. Run `wa` to build and watch the Bionic server. The web assets are now
+   compiled automatically as part of the build process.
 1. You can now access the front end on `http://localhost:7703`.
 
 ## Running the integration tests

--- a/Justfile
+++ b/Justfile
@@ -38,14 +38,11 @@ wa:
     mold -run cargo watch --workdir /workspace/ \
         -w crates/web-pages -w crates/llm-proxy -w crates/integrations \
         -w crates/web-server -w crates/db -w crates/web-assets/dist \
-        -w crates/web-assets/images \
+        -w crates/web-assets/images -w crates/web-assets/typescript \
+        -w crates/web-assets/scss -w crates/web-assets/index.ts \
+        -w crates/web-assets/input.css \
         --no-gitignore -x "run --bin web-server"
 
-wp:
-    npm install --prefix /workspace/crates/web-assets && npm run start --prefix /workspace/crates/web-assets
-
-wt:
-    cd /workspace/crates/web-assets && tailwind-extra -i ./input.css -o ./dist/output.css --watch
 
 ws:
     cd /workspace/crates/static-website && cargo watch --workdir /workspace/crates/static-website -w ./content -w ./src --no-gitignore -x "run --bin static-website"

--- a/crates/web-assets/build.rs
+++ b/crates/web-assets/build.rs
@@ -1,15 +1,24 @@
 use cache_busters::generate_static_files_code;
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
-    let static_out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    // Install dependencies and build the front-end assets.
+    Command::new("npm")
+        .arg("ci")
+        .status()
+        .expect("failed to run `npm ci`");
 
-    // Example of multiple asset directories
-    let asset_dirs = vec![
-        PathBuf::from("./dist"), // Adjust your asset directories here
-        PathBuf::from("./images"),
-    ];
+    // Build the javascript and CSS bundles. This runs the `release` script which
+    // invokes tailwind-extra and Parcel to create files under `dist/`.
+    Command::new("npm")
+        .args(["run", "release"])
+        .status()
+        .expect("failed to run `npm run release`");
+
+    let static_out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let asset_dirs = vec![PathBuf::from("./dist"), PathBuf::from("./images")];
 
     generate_static_files_code(&static_out_dir, &asset_dirs).unwrap();
 }


### PR DESCRIPTION
## Summary
- invoke npm build steps in `crates/web-assets/build.rs`
- remove `wp` and `wt` tasks from `Justfile`
- watch asset sources in `wa` task
- update CONTRIBUTING docs

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: tools::read_document::tests::test_accumulate_sections_limit)*

------
https://chatgpt.com/codex/tasks/task_e_6857c331e7048320afd9f2685af7fd95