### PR TITLE
Add dataset tools for RAG

### DIFF
--- a/crates/integrations/tool_executor.rs
+++ b/crates/integrations/tool_executor.rs
@@ -104,6 +104,22 @@ pub async fn get_tools(
         conversation_id,
     )));
 
+    debug!("Adding dataset tools with database pool");
+    tools.push(Arc::new(tools::list_datasets::ListDatasetsTool::new(
+        pool.clone(),
+        sub.clone(),
+        prompt_id,
+    )));
+    tools.push(Arc::new(
+        tools::list_dataset_files::ListDatasetFilesTool::new(pool.clone(), sub.clone()),
+    ));
+    tools.push(Arc::new(tools::search_context::SearchContextTool::new(
+        pool.clone(),
+        sub.clone(),
+        conversation_id,
+        prompt_id,
+    )));
+
     // Get external integration tools
     debug!("Getting external integration tools");
     let external_tools = match get_external_integration_tools(pool, sub, prompt_id).await {

--- a/crates/integrations/tool_registry.rs
+++ b/crates/integrations/tool_registry.rs
@@ -53,12 +53,18 @@ pub fn get_integrations(scope: Option<ToolScope>) -> Vec<IntegrationTool> {
         },
         IntegrationTool {
             scope: ToolScope::Rag,
-            title: "Tools to search RAG context".into(),
-            definitions: vec![tools::search_context::get_tool_definition()],
+            title: "Tools to work with datasets".into(),
+            definitions: vec![
+                tools::list_datasets::get_tool_definition(),
+                tools::list_dataset_files::get_tool_definition(),
+                tools::search_context::get_tool_definition(),
+            ],
             definitions_json: serde_json::to_string_pretty(&vec![
+                tools::list_datasets::get_tool_definition(),
+                tools::list_dataset_files::get_tool_definition(),
                 tools::search_context::get_tool_definition(),
             ])
-            .expect("Failed to serialize search_context tool to JSON"),
+            .expect("Failed to serialize RAG tools to JSON"),
         },
     ];
 

--- a/crates/integrations/tools/list_dataset_files.rs
+++ b/crates/integrations/tools/list_dataset_files.rs
@@ -1,0 +1,109 @@
+use crate::tool::ToolInterface;
+use async_trait::async_trait;
+use db::{queries, Pool, Transaction};
+use openai_api::{BionicToolDefinition, ChatCompletionFunctionDefinition};
+use serde::Deserialize;
+use serde_json::json;
+use tracing;
+
+#[derive(Debug, Deserialize)]
+struct ListDatasetFilesParams {
+    dataset_id: i32,
+}
+
+pub struct ListDatasetFilesTool {
+    pool: Pool,
+    sub: String,
+}
+
+impl ListDatasetFilesTool {
+    pub fn new(pool: Pool, sub: String) -> Self {
+        Self { pool, sub }
+    }
+}
+
+pub fn get_tool_definition() -> BionicToolDefinition {
+    BionicToolDefinition {
+        r#type: "function".to_string(),
+        function: ChatCompletionFunctionDefinition {
+            name: "list_dataset_files".to_string(),
+            description: Some("List all files within a specific dataset.".to_string()),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "dataset_id": {"type": "integer", "description": "ID of the dataset"}
+                },
+                "required": ["dataset_id"]
+            })),
+        },
+    }
+}
+
+async fn list_files(
+    transaction: &Transaction<'_>,
+    dataset_id: i32,
+) -> Result<serde_json::Value, serde_json::Value> {
+    let docs = queries::documents::documents()
+        .bind(transaction, &dataset_id)
+        .all()
+        .await
+        .map_err(|e| json!({"error": "Failed to get documents", "details": e.to_string()}))?;
+
+    Ok(json!({
+        "files": docs
+            .iter()
+            .map(|d| json!({
+                "document_id": d.id,
+                "name": d.file_name,
+                "size": d.content_size,
+                "batches": d.batches
+            }))
+            .collect::<Vec<_>>()
+    }))
+}
+
+#[async_trait]
+impl ToolInterface for ListDatasetFilesTool {
+    fn get_tool(&self) -> BionicToolDefinition {
+        get_tool_definition()
+    }
+
+    async fn execute(&self, arguments: &str) -> Result<serde_json::Value, serde_json::Value> {
+        let params: ListDatasetFilesParams = serde_json::from_str(arguments)
+            .map_err(|e| json!({"error": "Invalid parameters", "details": e.to_string()}))?;
+
+        let mut client = self.pool.get().await.map_err(
+            |e| json!({"error": "Failed to get database client", "details": e.to_string()}),
+        )?;
+        let transaction = client.transaction().await.map_err(
+            |e| json!({"error": "Failed to start transaction", "details": e.to_string()}),
+        )?;
+
+        db::authz::set_row_level_security_user_id(&transaction, self.sub.clone())
+            .await
+            .map_err(|e| json!({"error": "Failed to set RLS", "details": e.to_string()}))?;
+
+        let result = list_files(&transaction, params.dataset_id).await;
+
+        if result.is_ok() {
+            transaction.commit().await.map_err(
+                |e| json!({"error": "Failed to commit transaction", "details": e.to_string()}),
+            )?;
+        } else {
+            transaction.rollback().await.ok();
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_list_dataset_files_tool() {
+        let tool = get_tool_definition();
+        assert_eq!(tool.function.name, "list_dataset_files");
+    }
+}

--- a/crates/integrations/tools/list_datasets.rs
+++ b/crates/integrations/tools/list_datasets.rs
@@ -1,0 +1,98 @@
+use crate::tool::ToolInterface;
+use async_trait::async_trait;
+use db::{queries, Pool, Transaction};
+use openai_api::{BionicToolDefinition, ChatCompletionFunctionDefinition};
+use serde_json::json;
+use tracing;
+
+pub struct ListDatasetsTool {
+    pool: Pool,
+    sub: String,
+    prompt_id: i32,
+}
+
+impl ListDatasetsTool {
+    pub fn new(pool: Pool, sub: String, prompt_id: i32) -> Self {
+        Self {
+            pool,
+            sub,
+            prompt_id,
+        }
+    }
+}
+
+pub fn get_tool_definition() -> BionicToolDefinition {
+    BionicToolDefinition {
+        r#type: "function".to_string(),
+        function: ChatCompletionFunctionDefinition {
+            name: "list_datasets".to_string(),
+            description: Some("List all datasets connected to this assistant.".to_string()),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            })),
+        },
+    }
+}
+
+async fn list_datasets(
+    transaction: &Transaction<'_>,
+    prompt_id: i32,
+) -> Result<serde_json::Value, serde_json::Value> {
+    let datasets = queries::prompts::prompt_datasets()
+        .bind(transaction, &prompt_id)
+        .all()
+        .await
+        .map_err(|e| json!({"error": "Failed to get datasets", "details": e.to_string()}))?;
+
+    Ok(json!({
+        "datasets": datasets
+            .iter()
+            .map(|d| json!({"dataset_id": d.dataset_id, "name": d.name}))
+            .collect::<Vec<_>>()
+    }))
+}
+
+#[async_trait]
+impl ToolInterface for ListDatasetsTool {
+    fn get_tool(&self) -> BionicToolDefinition {
+        get_tool_definition()
+    }
+
+    async fn execute(&self, _arguments: &str) -> Result<serde_json::Value, serde_json::Value> {
+        let mut client = self.pool.get().await.map_err(
+            |e| json!({"error": "Failed to get database client", "details": e.to_string()}),
+        )?;
+        let transaction = client.transaction().await.map_err(
+            |e| json!({"error": "Failed to start transaction", "details": e.to_string()}),
+        )?;
+
+        db::authz::set_row_level_security_user_id(&transaction, self.sub.clone())
+            .await
+            .map_err(|e| json!({"error": "Failed to set RLS", "details": e.to_string()}))?;
+
+        let result = list_datasets(&transaction, self.prompt_id).await;
+
+        if result.is_ok() {
+            transaction.commit().await.map_err(
+                |e| json!({"error": "Failed to commit transaction", "details": e.to_string()}),
+            )?;
+        } else {
+            transaction.rollback().await.ok();
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_list_datasets_tool() {
+        let tool = get_tool_definition();
+        assert_eq!(tool.function.name, "list_datasets");
+    }
+}

--- a/crates/integrations/tools/mod.rs
+++ b/crates/integrations/tools/mod.rs
@@ -1,3 +1,5 @@
+pub mod list_dataset_files;
+pub mod list_datasets;
 pub mod list_documents;
 pub mod open_api_tool;
 pub mod read_document;

--- a/crates/llm-proxy/prompt.rs
+++ b/crates/llm-proxy/prompt.rs
@@ -87,7 +87,6 @@ pub async fn get_prompt_integration_tools(
             })?;
 
         if !datasets.is_empty() {
-            filtered_tools.extend(get_tools(ToolScope::DocumentIntelligence));
             filtered_tools.extend(get_tools(ToolScope::Rag));
         }
     }


### PR DESCRIPTION
## Summary
- add dataset tools to list available datasets and list files in a dataset
- expose new dataset tools in the registry and tool executor
- update llm-proxy prompt logic to only add RAG tools when datasets exist

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6857fb4c87d083209d60c5df113c47f6