### PR TITLE
Limit console uploads to five files

### DIFF
--- a/crates/web-assets/typescript/console/file-upload.ts
+++ b/crates/web-assets/typescript/console/file-upload.ts
@@ -43,9 +43,12 @@ export function fileUpload() {
   // File selection handler
   fileInput.addEventListener('change', () => {
     if (fileInput.files && fileInput.files.length > 0) {
-      // Add each file to our collection
-      Array.from(fileInput.files).forEach(file => {
-        // Use a unique key combining name and last modified time
+      const availableSlots = Math.max(0, 5 - selectedFiles.size);
+      const files = Array.from(fileInput.files);
+      if (files.length > availableSlots) {
+        alert('You can only upload up to 5 files.');
+      }
+      files.slice(0, availableSlots).forEach(file => {
         const key = `${file.name}-${file.lastModified}`;
         if (!selectedFiles.has(key)) {
           selectedFiles.set(key, file);


### PR DESCRIPTION
## Summary
- restrict number of uploaded files in console to five

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_6857fba264248320a74a577860622f45