### PR TITLE
Disable Turbo for OAuth connect link

### DIFF
--- a/crates/web-pages/integrations/connections_section.rs
+++ b/crates/web-pages/integrations/connections_section.rs
@@ -2,7 +2,6 @@
 use super::api_key_cards::ApiKeyCards;
 use super::api_key_form::ApiKeyForm;
 use super::oauth2_cards::Oauth2Cards;
-use crate::routes;
 use daisy_rsx::*;
 use db::authz::Rbac;
 use db::{ApiKeyConnection, Oauth2Connection};
@@ -84,12 +83,11 @@ pub fn ConnectionsSection(
                             "OAuth2 Connections"
                         }
                         if oauth_client_configured {
-                            Button {
-                                button_type: ButtonType::Link,
-                                href: routes::integrations::Connect { team_id, integration_id }.to_string(),
-                                button_style: ButtonStyle::Outline,
-                                button_scheme: ButtonScheme::Primary,
-                                "Add OAuth2 Connection"
+                            super::oauth_connect_button::OauthConnectButton {
+                                team_id,
+                                integration_id,
+                                class: "btn btn-primary btn-sm btn-outline".to_string(),
+                                label: "Add OAuth2 Connection".to_string(),
                             }
                         } else {
                             Button {

--- a/crates/web-pages/integrations/integration_card.rs
+++ b/crates/web-pages/integrations/integration_card.rs
@@ -70,11 +70,11 @@ pub fn IntegrationCard(integration: IntegrationSummary, team_id: i32) -> Element
                 div {
                     class: "flex flex-col justify-center ml-4",
                     if integration.oauth_client_configured {
-                        a {
-                            class: "btn btn-secondary btn-sm ",
-                            "data-turbo": "false",
-                            href: crate::routes::integrations::Connect { team_id, integration_id: integration.id }.to_string(),
-                            "Connect"
+                        super::oauth_connect_button::OauthConnectButton {
+                            team_id,
+                            integration_id: integration.id,
+                            class: "btn btn-secondary btn-sm ".to_string(),
+                            label: "Connect".to_string(),
                         }
                     } else {
                         Button {

--- a/crates/web-pages/integrations/mod.rs
+++ b/crates/web-pages/integrations/mod.rs
@@ -6,6 +6,7 @@ pub mod integration_card;
 pub mod integration_header;
 pub mod integration_type;
 pub mod oauth2_cards;
+pub mod oauth_connect_button;
 pub mod page;
 pub mod parameter_renderer;
 pub mod upsert;

--- a/crates/web-pages/integrations/oauth_connect_button.rs
+++ b/crates/web-pages/integrations/oauth_connect_button.rs
@@ -1,0 +1,23 @@
+#![allow(non_snake_case)]
+use crate::routes;
+use dioxus::prelude::*;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct OauthConnectButtonProps {
+    team_id: i32,
+    integration_id: i32,
+    label: String,
+    class: String,
+}
+
+#[component]
+pub fn OauthConnectButton(props: OauthConnectButtonProps) -> Element {
+    rsx! {
+        a {
+            class: "{props.class}",
+            "data-turbo": "false",
+            href: routes::integrations::Connect { team_id: props.team_id, integration_id: props.integration_id }.to_string(),
+            "{props.label}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- disable Turbo on OAuth2 connect link so CSP doesn't block redirect
- refactor repeated OAuth connect link to reusable component

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`


------
https://chatgpt.com/codex/tasks/task_e_68594c478b04832099459478bad9fa15