### PR TITLE
Handle tool_call index in streaming merge

### DIFF
--- a/crates/integrations/test_async.rs
+++ b/crates/integrations/test_async.rs
@@ -37,6 +37,7 @@ async fn test_execute_tool_call_with_tools() {
     // Create a tool call
     let tool_call = ToolCall {
         id: "call_123".to_string(),
+        index: None,
         r#type: "function".to_string(),
         function: ToolCallFunction {
             name: "get_current_time_and_date".to_string(),

--- a/crates/integrations/tool_executor.rs
+++ b/crates/integrations/tool_executor.rs
@@ -213,6 +213,7 @@ mod tests {
 
         let tool_call = ToolCall {
             id: "call_123".to_string(),
+            index: None,
             r#type: "function".to_string(),
             function: ToolCallFunction {
                 name: "get_current_time_and_date".to_string(),

--- a/crates/openai-api/tests/tool_call_merge.rs
+++ b/crates/openai-api/tests/tool_call_merge.rs
@@ -1,0 +1,70 @@
+use openai_api::{
+    ChatCompletionChoiceDelta, ChatCompletionDelta, ChatCompletionMessageDelta,
+    ChatCompletionMessageRole, ToolCall, ToolCallFunction,
+};
+
+#[test]
+fn merge_tool_calls_with_indexes() {
+    let mut base = ChatCompletionDelta {
+        id: "id".to_string(),
+        object: "obj".to_string(),
+        created: 0,
+        model: "gpt".to_string(),
+        usage: None,
+        choices: vec![ChatCompletionChoiceDelta {
+            index: 0,
+            finish_reason: None,
+            delta: ChatCompletionMessageDelta {
+                role: Some(ChatCompletionMessageRole::Assistant),
+                content: None,
+                name: None,
+                tool_call_id: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_a".to_string(),
+                    index: Some(0),
+                    r#type: "function".to_string(),
+                    function: ToolCallFunction {
+                        name: "func_a".to_string(),
+                        arguments: "arg_a".to_string(),
+                    },
+                }]),
+            },
+        }],
+    };
+
+    let delta = ChatCompletionDelta {
+        id: "id".to_string(),
+        object: "obj".to_string(),
+        created: 0,
+        model: "gpt".to_string(),
+        usage: None,
+        choices: vec![ChatCompletionChoiceDelta {
+            index: 0,
+            finish_reason: None,
+            delta: ChatCompletionMessageDelta {
+                role: Some(ChatCompletionMessageRole::Assistant),
+                content: None,
+                name: None,
+                tool_call_id: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_b".to_string(),
+                    index: Some(1),
+                    r#type: "function".to_string(),
+                    function: ToolCallFunction {
+                        name: "func_b".to_string(),
+                        arguments: "arg_b".to_string(),
+                    },
+                }]),
+            },
+        }],
+    };
+
+    base.merge(delta).unwrap();
+
+    let tool_calls = base.choices[0].delta.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 2);
+    assert_eq!(tool_calls[0].id, "call_a");
+    assert_eq!(tool_calls[0].index, Some(0));
+    assert_eq!(tool_calls[1].id, "call_b");
+    assert_eq!(tool_calls[1].index, Some(1));
+}


### PR DESCRIPTION
## Summary
- support optional `index` field in `ToolCall`
- merge tool calls into their declared index slots
- update integrations tests for the new struct field
- add regression test ensuring tool calls merge correctly

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_685e4aa320488320b5803bc6e63d17ac