### PR TITLE
Fix redirect bug by removing Referrer-Policy header

### DIFF
--- a/crates/k8s-operator/envoy/envoy.yaml
+++ b/crates/k8s-operator/envoy/envoy.yaml
@@ -45,7 +45,6 @@ static_resources:
                     response_handle:headers():add("X-Frame-Options", "deny");
                     response_handle:headers():add("X-XSS-Protection", "1; mode=block");
                     response_handle:headers():add("X-Content-Type-Options", "nosniff");
-                    response_handle:headers():add("Referrer-Policy", "no-referrer");
                     response_handle:headers():add("X-Download-Options", "noopen");
                     response_handle:headers():add("X-DNS-Prefetch-Control", "off");
                     response_handle:headers():add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");


### PR DESCRIPTION
## Summary
- remove Envoy `Referrer-Policy` header that stripped the browser's `Referer`

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_685edc122c3883208a9078eee48f06a3