### PR TITLE
Display model prompt names when creating assistants

### DIFF
--- a/crates/web-pages/my_assistants/upsert.rs
+++ b/crates/web-pages/my_assistants/upsert.rs
@@ -2,7 +2,7 @@
 use crate::app_layout::{Layout, SideBar};
 use daisy_rsx::*;
 use db::authz::Rbac;
-use db::{Category, Model, Visibility};
+use db::{Category, Prompt, Visibility};
 use dioxus::prelude::*;
 use serde::Deserialize;
 use validator::Validate;
@@ -31,7 +31,7 @@ pub struct PromptForm {
     #[serde(skip)]
     pub categories: Vec<Category>,
     #[serde(skip)]
-    pub models: Vec<Model>,
+    pub models: Vec<Prompt>,
 }
 
 pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
@@ -184,11 +184,11 @@ pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
                                                 name: "model_id",
                                                 value: "{prompt.model_id}",
                                                 required: true,
-                                                for model in &prompt.models {
+                                                for model_prompt in &prompt.models {
                                                     SelectOption {
-                                                        value: "{model.id}",
+                                                        value: "{model_prompt.model_id}",
                                                         selected_value: "{prompt.model_id}",
-                                                        "{model.name}"
+                                                        "{model_prompt.name}"
                                                     }
                                                 }
                                             }

--- a/crates/web-server/handlers/assistants/loaders.rs
+++ b/crates/web-server/handlers/assistants/loaders.rs
@@ -3,7 +3,7 @@ use axum::extract::Extension;
 use axum::response::Html;
 use db::authz;
 use db::Pool;
-use db::{queries, ModelType};
+use db::{queries, PromptType};
 use web_pages::visibility_to_string;
 use web_pages::{
     assistants,
@@ -55,8 +55,8 @@ pub async fn new_assistant_loader(
         .all()
         .await?;
 
-    let models = queries::models::models()
-        .bind(&transaction, &ModelType::LLM)
+    let models = queries::prompts::prompts()
+        .bind(&transaction, &team_id, &PromptType::Model)
         .all()
         .await?;
 
@@ -113,8 +113,8 @@ pub async fn edit_assistant_loader(
         .all()
         .await?;
 
-    let models = queries::models::models()
-        .bind(&transaction, &ModelType::LLM)
+    let models = queries::prompts::prompts()
+        .bind(&transaction, &team_id, &PromptType::Model)
         .all()
         .await?;
 


### PR DESCRIPTION
## Summary
- use model prompts instead of raw models in the assistant form
- load prompts with `PromptType::Model` in assistant loaders

## Testing
- `cargo fmt --all`
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: No such file or directory in build script)*

------
https://chatgpt.com/codex/tasks/task_e_685fc3e534348320952b7fc2921edf24