### PR TITLE
Refactor OAuth client card

### DIFF
--- a/crates/web-pages/oauth_clients/oauth_client_card.rs
+++ b/crates/web-pages/oauth_clients/oauth_client_card.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use crate::components::card_item::CardItem;
 use crate::components::confirm_modal::ConfirmModal;
 use crate::routes;
 use daisy_rsx::*;
@@ -14,53 +15,40 @@ pub struct OauthClientCardProps {
 
 #[component]
 pub fn OauthClientCard(props: OauthClientCardProps) -> Element {
+    let delete_id = format!("delete_oauth_client_{}", props.oauth_client.id);
     rsx!(
-        Card {
-            class: "p-3 mt-5 flex flex-row",
-            div {
-                class: "flex flex-row flex-1 min-w-0",
-
-                Avatar {
-                    avatar_size: AvatarSize::Medium,
-                    name: "{props.oauth_client.provider}"
-                }
-                div {
-                    class: "ml-4 text-sm flex flex-col justify-center flex-1 min-w-0",
-                    h2 {
-                        class: "font-semibold text-base-content",
-                        "{props.oauth_client.provider}"
-                    }
-                    p {
-                        class: "text-base-content/70 truncate overflow-hidden whitespace-nowrap",
-                        "Client ID: {props.oauth_client.client_id}"
-                    }
-                    p {
-                        class: "text-xs text-base-content/50",
-                        "Created: {props.oauth_client.created_at}"
-                    }
-                }
+        CardItem {
+            class: Some("mt-5".into()),
+            popover_target: None,
+            image_src: None,
+            avatar_name: Some(props.oauth_client.provider.clone()),
+            title: props.oauth_client.provider.clone(),
+            description: Some(rsx!(span { "Client ID: {props.oauth_client.client_id}" })),
+            footer: Some(rsx!(span { "Created: {props.oauth_client.created_at}" })),
+            count_labels: vec![],
+            action: if props.rbac.is_sys_admin {
+                Some(rsx!(Button {
+                    button_scheme: ButtonScheme::Error,
+                    button_size: ButtonSize::Small,
+                    popover_target: delete_id.clone(),
+                    "Delete"
+                }))
+            } else {
+                None
             }
-            if props.rbac.is_sys_admin {
-                div {
-                    class: "flex flex-col justify-center ml-4",
-                    Button {
-                        button_scheme: ButtonScheme::Error,
-                        button_size: ButtonSize::Small,
-                        popover_target: format!("delete_oauth_client_{}", props.oauth_client.id),
-                        "Delete"
-                    }
-                    ConfirmModal {
-                        action: routes::oauth_clients::Delete {
-                            team_id: props.team_id,
-                            id: props.oauth_client.id
-                        }.to_string(),
-                        trigger_id: format!("delete_oauth_client_{}", props.oauth_client.id),
-                        submit_label: "Delete OAuth Client".to_string(),
-                        heading: "Delete OAuth Client".to_string(),
-                        warning: format!("Are you sure you want to delete the OAuth client for {}? This action cannot be undone.", props.oauth_client.provider),
-                        hidden_fields: vec![]
-                    }
-                }
+        }
+
+        if props.rbac.is_sys_admin {
+            ConfirmModal {
+                action: routes::oauth_clients::Delete {
+                    team_id: props.team_id,
+                    id: props.oauth_client.id
+                }.to_string(),
+                trigger_id: delete_id,
+                submit_label: "Delete OAuth Client".to_string(),
+                heading: "Delete OAuth Client".to_string(),
+                warning: format!("Are you sure you want to delete the OAuth client for {}? This action cannot be undone.", props.oauth_client.provider),
+                hidden_fields: vec![]
             }
         }
     )


### PR DESCRIPTION
## Summary
- reuse `CardItem` component for OAuth client cards

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine --no-run`

------
https://chatgpt.com/codex/tasks/task_e_685ff7034454832099a5c25b87725537