### PR TITLE
Update automation model dropdown

### DIFF
--- a/crates/web-pages/automations/upsert.rs
+++ b/crates/web-pages/automations/upsert.rs
@@ -2,7 +2,7 @@
 use crate::app_layout::{Layout, SideBar};
 use daisy_rsx::*;
 use db::authz::Rbac;
-use db::{Category, Model, Visibility};
+use db::{Category, Prompt, Visibility};
 use dioxus::prelude::*;
 use serde::Deserialize;
 use validator::Validate;
@@ -31,7 +31,7 @@ pub struct PromptForm {
     #[serde(skip)]
     pub categories: Vec<Category>,
     #[serde(skip)]
-    pub models: Vec<Model>,
+    pub models: Vec<Prompt>,
 }
 
 pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
@@ -180,11 +180,11 @@ pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
                                                 name: "model_id",
                                                 value: "{prompt.model_id}",
                                                 required: true,
-                                                for model in &prompt.models {
+                                                for model_prompt in &prompt.models {
                                                     SelectOption {
-                                                        value: "{model.id}",
+                                                        value: "{model_prompt.model_id}",
                                                         selected_value: "{prompt.model_id}",
-                                                        "{model.name}"
+                                                        "{model_prompt.name}"
                                                     }
                                                 }
                                             }

--- a/crates/web-server/handlers/automations/loaders.rs
+++ b/crates/web-server/handlers/automations/loaders.rs
@@ -3,7 +3,7 @@ use axum::extract::Extension;
 use axum::response::Html;
 use db::authz;
 use db::Pool;
-use db::{queries, ModelType};
+use db::{queries, PromptType};
 use web_pages::routes::automations::{Edit, New};
 use web_pages::visibility_to_string;
 
@@ -27,8 +27,8 @@ pub async fn new_automation_loader(
         .all()
         .await?;
 
-    let models = queries::models::models()
-        .bind(&transaction, &ModelType::LLM)
+    let models = queries::prompts::prompts()
+        .bind(&transaction, &team_id, &PromptType::Model)
         .all()
         .await?;
 
@@ -85,8 +85,8 @@ pub async fn edit_automation_loader(
         .all()
         .await?;
 
-    let models = queries::models::models()
-        .bind(&transaction, &ModelType::LLM)
+    let models = queries::prompts::prompts()
+        .bind(&transaction, &team_id, &PromptType::Model)
         .all()
         .await?;
 


### PR DESCRIPTION
## Summary
- use `Prompt` data for automation models
- load model prompts instead of models in loaders

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`


------
https://chatgpt.com/codex/tasks/task_e_685ff68fb7748320a63781c651349513