### PR TITLE
Update console examples to fill main prompt

### DIFF
--- a/crates/web-assets/index.ts
+++ b/crates/web-assets/index.ts
@@ -26,6 +26,7 @@ import { disableSubmitButton } from './typescript/disable-submit-button'
 import { themeSwitcher, setTheme } from './typescript/layout/theme-switcher'
 import { speechToText } from './typescript/console/speach-to-text';
 import { fileUpload } from './typescript/console/file-upload';
+import { examplePrompts } from './typescript/console/example-prompts';
 
 // Hotwired Turbo
 import '@hotwired/turbo'
@@ -37,6 +38,7 @@ function loadEverything() {
     modalTriggers()
     toggleVisibility()
     autoExpand()
+    examplePrompts()
     formatter()
     streamingChat()
     copyPaste()

--- a/crates/web-assets/typescript/console/example-prompts.ts
+++ b/crates/web-assets/typescript/console/example-prompts.ts
@@ -1,0 +1,15 @@
+export const examplePrompts = () => {
+  const buttons = document.querySelectorAll<HTMLButtonElement>('.example-prompt');
+  const textarea = document.querySelector<HTMLTextAreaElement>('textarea[name="message"]');
+  buttons.forEach(button => {
+    button.addEventListener('click', (e) => {
+      e.preventDefault();
+      const example = button.dataset.example;
+      if (example && textarea) {
+        textarea.value = example;
+        const event = new Event('input', { bubbles: true });
+        textarea.dispatchEvent(event);
+      }
+    });
+  });
+};

--- a/crates/web-pages/assistants/view_prompt.rs
+++ b/crates/web-pages/assistants/view_prompt.rs
@@ -55,8 +55,6 @@ pub fn ViewDrawer(team_id: i32, prompt: Prompt, trigger_id: String) -> Element {
                             if let Some(example) = example {
                                 if ! example.is_empty() {
                                     ExampleForm {
-                                        team_id,
-                                        prompt_id: prompt.id,
                                         example: example
                                     }
                                 }

--- a/crates/web-pages/console/empty_stream.rs
+++ b/crates/web-pages/console/empty_stream.rs
@@ -1,12 +1,10 @@
 #![allow(non_snake_case)]
-use crate::routes;
-
 use assets::files::*;
 use db::queries::prompts::SinglePrompt;
 use dioxus::prelude::*;
 
 #[component]
-pub fn EmptyStream(prompt: SinglePrompt, conversation_id: Option<i64>, team_id: i32) -> Element {
+pub fn EmptyStream(prompt: SinglePrompt, team_id: i32) -> Element {
     let examples: Vec<Option<String>> = vec![
         prompt.example1,
         prompt.example2,
@@ -26,8 +24,6 @@ pub fn EmptyStream(prompt: SinglePrompt, conversation_id: Option<i64>, team_id: 
                     if let Some(example) = example {
                         if ! example.is_empty() {
                             ExampleForm {
-                                team_id,
-                                prompt_id: prompt.id,
                                 example: example
                             }
                         }
@@ -39,34 +35,19 @@ pub fn EmptyStream(prompt: SinglePrompt, conversation_id: Option<i64>, team_id: 
 }
 
 #[component]
-pub fn ExampleForm(prompt_id: i32, team_id: i32, example: String) -> Element {
+pub fn ExampleForm(example: String) -> Element {
     rsx! {
-        form {
-            class: "w-full",
-            method: "post",
-            action: routes::console::SendMessage{team_id}.to_string(),
-            enctype: "multipart/form-data",
-            input {
-                "type": "hidden",
-                name: "prompt_id",
-                value: "{prompt_id}"
+        button {
+            class: "example-prompt flex flex-col h-full w-full rounded-2xl border p-3 text-start",
+            "type": "button",
+            "data-example": "{example}",
+            img {
+                height: "16",
+                width: "16",
+                class: "svg-icon mb-2",
+                src: ai_svg.name
             }
-            input {
-                "type": "hidden",
-                name: "message",
-                value: "{example}"
-            }
-            button {
-                class: "flex flex-col h-full w-full rounded-2xl border p-3 text-start",
-                "type": "submit",
-                img {
-                    height: "16",
-                    width: "16",
-                    class: "svg-icon mb-2",
-                    src: ai_svg.name
-                }
-                "{example}"
-            }
+            "{example}"
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace example forms with buttons that insert example text into main console input
- handle example button clicks with new `examplePrompts` script
- register the script in the web assets bundle

## Testing
- `cargo check -p web-pages` *(fails: build script for `assets` not found)*
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: build script for `assets` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686011831f3083209d6c1c7f43b39ecf