### PR TITLE
Fallback doc context when model lacks tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "http 1.1.0",
  "integrations",
  "openai-api",
+ "rag-engine",
  "reqwest",
  "reqwest-eventsource",
  "serde",

--- a/crates/llm-proxy/Cargo.toml
+++ b/crates/llm-proxy/Cargo.toml
@@ -11,6 +11,7 @@ db = { path = "../db" }
 embeddings-api = { path = "../embeddings-api" }
 integrations = { path = "../integrations" }
 openai-api = { path = "../openai-api" }
+rag-engine = { path = "../rag-engine" }
 
 axum = { version = "0.8", features = ["multipart"] }
 axum-extra = { version = "0.10", features = ["form", "typed-routing", "cookie"] }

--- a/crates/llm-proxy/api_chat_stream.rs
+++ b/crates/llm-proxy/api_chat_stream.rs
@@ -164,9 +164,14 @@ async fn create_request(
         .one()
         .await?;
 
-    let messages =
-        super::prompt::execute_prompt(transaction, prompt.clone(), None, completion.messages)
-            .await?;
+    let messages = super::prompt::execute_prompt(
+        transaction,
+        prompt.clone(),
+        None,
+        completion.messages,
+        Vec::new(),
+    )
+    .await?;
     let completion = BionicChatCompletionRequest {
         messages,
         ..completion

--- a/crates/llm-proxy/ui_chat_stream.rs
+++ b/crates/llm-proxy/ui_chat_stream.rs
@@ -358,11 +358,22 @@ async fn create_request(
 
     let chat_history = chat_converter::convert_chat_to_messages(chat_history);
 
+    let mut extra_context = Vec::new();
+    if !capabilities
+        .iter()
+        .any(|c| c.capability == db::ModelCapability::tool_use)
+        && attachment_count > 0
+    {
+        extra_context =
+            super::prompt::latest_attachment_context(&transaction, conversation.id).await?;
+    }
+
     let messages = super::prompt::execute_prompt(
         &transaction,
         prompt.clone(),
         Some(conversation.id),
         chat_history,
+        extra_context,
     )
     .await?;
 


### PR DESCRIPTION
## Summary
- add `rag-engine` dependency for `llm-proxy`
- inline latest attachment as context when model doesn't support tools
- skip saving chunk IDs for inlined attachments
- expose helper `latest_attachment_context`

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine --exclude assets --exclude web-pages --exclude web-server`

------
https://chatgpt.com/codex/tasks/task_e_68600b9aa2fc8320a5bc084cd27ee396