### PR TITLE
Add dismiss handler to snackbar

### DIFF
--- a/crates/web-assets/typescript/layout/snackbar.ts
+++ b/crates/web-assets/typescript/layout/snackbar.ts
@@ -13,19 +13,25 @@ export const snackBar = () => {
             messageElement.textContent = message;
         }
 
+        const hideSnackbar = () => {
+            snackbar.classList.remove('translate-y-0', 'opacity-100');
+            snackbar.classList.add('translate-y-full', 'opacity-0');
+        };
+
         // Show the snackbar by removing the classes that hide it
-        snackbar.classList.remove('translate-y-full', 'opacity-0'); // Show
-        snackbar.classList.add('translate-y-0', 'opacity-100'); // Make it fully visible
+        snackbar.classList.remove('translate-y-full', 'opacity-0');
+        snackbar.classList.add('translate-y-0', 'opacity-100');
+
+        const dismiss = snackbar.querySelector<HTMLButtonElement>('button.action');
+        if (dismiss) {
+            dismiss.addEventListener('click', hideSnackbar, { once: true });
+        }
 
         // Delete the cookie after reading its value
         deleteCookie(COOKIE_NAME);
 
         // Automatically hide the snackbar after 4 seconds
-        setTimeout(() => {
-            // Slide up and hide the snackbar
-            snackbar.classList.remove('translate-y-0', 'opacity-100'); // Hide
-            snackbar.classList.add('translate-y-full', 'opacity-0'); // Slide up
-        }, 4000);
+        setTimeout(hideSnackbar, 4000);
     }
 };
 


### PR DESCRIPTION
## Summary
- enable manual snackbar dismissal

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine --exclude web-assets` *(fails: build script for `assets` requires missing paths)*

------
https://chatgpt.com/codex/tasks/task_e_686146d061408320bccab3380ed7f2e5