### PR TITLE
Add badge outline style and small size

### DIFF
--- a/crates/web-assets/input.css
+++ b/crates/web-assets/input.css
@@ -6,7 +6,8 @@
 @source 'typescript/**/*.ts';
 @source inline("modal modal-box modal-action");
 @source inline("breadcrumbs");
-@source inline("badge badge-neutral badge-primary badge-secondary badge-accent badge-info badge-success badge-warning badge-error");
+@source inline("badge badge-neutral badge-primary badge-outline badge-secondary badge-accent badge-info badge-success badge-warning badge-error");
+@source inline("badge-md badge-sm");
 @source inline("btn btn-secondary btn-accent btn-info btn-success btn-warning btn-error btn-outline btn-dash btn-soft btn-ghost btn-link btn-active btn-disabled btn-xs btn-sm btn-md btn-lg btn-xl btn-wide btn-block btn-square btn-circle");
 @source inline("tab tabs tab-content tabs-border");
 @source inline("tooltip tooltip-info");

--- a/crates/web-pages/api_keys/page.rs
+++ b/crates/web-pages/api_keys/page.rs
@@ -110,6 +110,8 @@ pub fn PromptType(prompt_type: DBPromptType) -> Element {
             Badge {
                 class: "mr-2 truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Model"
             }
         ),
@@ -117,6 +119,8 @@ pub fn PromptType(prompt_type: DBPromptType) -> Element {
             Badge {
                 class: "mr-2 truncate",
                 badge_color: BadgeColor::Accent,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Assistant"
             }
         ),
@@ -124,6 +128,8 @@ pub fn PromptType(prompt_type: DBPromptType) -> Element {
             Badge {
                 class: "mr-2 truncate",
                 badge_color: BadgeColor::Accent,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Assistant"
             }
         ),

--- a/crates/web-pages/assistants/visibility.rs
+++ b/crates/web-pages/assistants/visibility.rs
@@ -10,6 +10,8 @@ pub fn VisLabel(visibility: Visibility) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Error,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "{crate::visibility_to_string(visibility)}"
             }
         ),
@@ -17,6 +19,8 @@ pub fn VisLabel(visibility: Visibility) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Accent,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "{crate::visibility_to_string(visibility)}"
             }
         ),
@@ -24,6 +28,8 @@ pub fn VisLabel(visibility: Visibility) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "{crate::visibility_to_string(visibility)}"
             }
         ),

--- a/crates/web-pages/audit_trail/table.rs
+++ b/crates/web-pages/audit_trail/table.rs
@@ -43,6 +43,8 @@ pub fn AuditTable(audits: Vec<AuditTrail>) -> Element {
                                     Badge {
                                         class: "mr-2",
                                         badge_color: BadgeColor::Neutral,
+                                        badge_style: BadgeStyle::Outline,
+                                        badge_size: BadgeSize::Sm,
                                         {super::access_type_to_string(audit.access_type)}
                                     }
                                 }
@@ -50,6 +52,8 @@ pub fn AuditTable(audits: Vec<AuditTrail>) -> Element {
                                     class: "text-right",
                                     Badge {
                                         badge_color: BadgeColor::Neutral,
+                                        badge_style: BadgeStyle::Outline,
+                                        badge_size: BadgeSize::Sm,
                                         {super::audit_action_to_string(audit.action)}
                                     }
                                 }

--- a/crates/web-pages/console/console_stream.rs
+++ b/crates/web-pages/console/console_stream.rs
@@ -150,6 +150,8 @@ fn FunctionCallTimeline(name: String, chat_id: i64, team_id: i32, pending: bool)
             }
             TimeLineBody {
                 Badge {
+                    badge_style: BadgeStyle::Outline,
+                    badge_size: BadgeSize::Sm,
                     "Function Call:"
                     strong {
                         class: "ml-2",

--- a/crates/web-pages/datasets/page.rs
+++ b/crates/web-pages/datasets/page.rs
@@ -98,6 +98,8 @@ pub fn page(
                                                 class: "max-sm:hidden",
                                                 Badge {
                                                     badge_color: BadgeColor::Accent,
+                                                    badge_style: BadgeStyle::Outline,
+                                                    badge_size: BadgeSize::Sm,
                                                     "By Title"
                                                 }
                                                 }

--- a/crates/web-pages/documents/page.rs
+++ b/crates/web-pages/documents/page.rs
@@ -152,6 +152,8 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
                         src,
                         Badge {
                             class: class,
+                            badge_style: BadgeStyle::Outline,
+                            badge_size: BadgeSize::Sm,
                             "Processing ({document.waiting} remaining)"
                         }
                     }
@@ -164,6 +166,8 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
                             text: "{text}",
                             Badge {
                                 badge_color: BadgeColor::Error,
+                                badge_style: BadgeStyle::Outline,
+                                badge_size: BadgeSize::Sm,
                                 "Failed"
                             }
                         }
@@ -173,7 +177,7 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
                         id,
                         src,
 
-                        Badge { "Queued" }
+                        Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Queued" }
                     }
                 } else if document.fail_count > 0 {
                     turbo-frame {
@@ -182,6 +186,8 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
 
                         Badge {
                             badge_color: BadgeColor::Error,
+                            badge_style: BadgeStyle::Outline,
+                            badge_size: BadgeSize::Sm,
                             "Processed ({document.fail_count} failed)"
                         }
                     }
@@ -192,6 +198,8 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
 
                         Badge {
                             badge_color: BadgeColor::Error,
+                            badge_style: BadgeStyle::Outline,
+                            badge_size: BadgeSize::Sm,
                             "Failed"
                         }
                     }
@@ -202,6 +210,8 @@ pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
 
                         Badge {
                             badge_color: BadgeColor::Success,
+                            badge_style: BadgeStyle::Outline,
+                            badge_size: BadgeSize::Sm,
                             "Processed"
                         }
                     }

--- a/crates/web-pages/integrations/integration_type.rs
+++ b/crates/web-pages/integrations/integration_type.rs
@@ -10,6 +10,8 @@ pub fn Integration(integration_type: IntegrationType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "MCP Server"
             }
         ),
@@ -17,6 +19,8 @@ pub fn Integration(integration_type: IntegrationType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Built In"
             }
         ),
@@ -24,6 +28,8 @@ pub fn Integration(integration_type: IntegrationType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Open API"
             }
         ),

--- a/crates/web-pages/models/model_card.rs
+++ b/crates/web-pages/models/model_card.rs
@@ -23,9 +23,9 @@ pub fn ModelCard(
         description: Some(rsx!(div {
             class: "flex gap-2 mt-1 text-xs",
             super::model_type::Model { model_type: model.model_type }
-            if has_function_calling { Badge { badge_style: BadgeStyle::Ghost, "Functions" } }
-            if has_vision { Badge { badge_style: BadgeStyle::Ghost, "Vision" } }
-            if has_tool_use { Badge { badge_style: BadgeStyle::Ghost, "Tools" } }
+            if has_function_calling { Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Functions" } }
+            if has_vision { Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Vision" } }
+            if has_tool_use { Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Tools" } }
         })),
         footer: None,
         image_src: None,

--- a/crates/web-pages/models/model_type.rs
+++ b/crates/web-pages/models/model_type.rs
@@ -10,6 +10,8 @@ pub fn Model(model_type: ModelType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Large Language Model"
             }
         ),
@@ -17,6 +19,8 @@ pub fn Model(model_type: ModelType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Accent,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Embeddings Model"
             }
         ),
@@ -24,6 +28,8 @@ pub fn Model(model_type: ModelType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Warning,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Text To Speech"
             }
         ),
@@ -31,6 +37,8 @@ pub fn Model(model_type: ModelType) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Neutral,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Image Generation"
             }
         ),

--- a/crates/web-pages/rate_limits/rate_table.rs
+++ b/crates/web-pages/rate_limits/rate_table.rs
@@ -32,12 +32,16 @@ pub fn RateTable(rate_limits: Vec<db::RateLimit>, team_id: i32) -> Element {
                                 td {
                                     Badge {
                                         badge_color: BadgeColor::Success,
+                                        badge_style: BadgeStyle::Outline,
+                                        badge_size: BadgeSize::Sm,
                                         "{limit.tpm_limit}"
                                     }
                                 }
                                 td {
                                     Badge {
                                         badge_color: BadgeColor::Success,
+                                        badge_style: BadgeStyle::Outline,
+                                        badge_size: BadgeSize::Sm,
                                         "{limit.rpm_limit}"
                                     }
                                 }

--- a/crates/web-pages/shared/integrations.rs
+++ b/crates/web-pages/shared/integrations.rs
@@ -41,6 +41,8 @@ pub fn Status(status: IntegrationStatus) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Active"
             }
         ),
@@ -48,6 +50,8 @@ pub fn Status(status: IntegrationStatus) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Warning,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Missing API Key"
             }
         ),
@@ -55,6 +59,8 @@ pub fn Status(status: IntegrationStatus) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Warning,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Missing Oauth2"
             }
         ),
@@ -62,6 +68,8 @@ pub fn Status(status: IntegrationStatus) -> Element {
             Badge {
                 class: "truncate",
                 badge_color: BadgeColor::Info,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Available"
             }
         ),

--- a/crates/web-pages/team/team_role.rs
+++ b/crates/web-pages/team/team_role.rs
@@ -10,6 +10,8 @@ pub fn Role(role: DBRole) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Accent,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "System Administrator"
             }
         ),
@@ -17,6 +19,8 @@ pub fn Role(role: DBRole) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Neutral,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Team Manager"
             }
         ),
@@ -24,6 +28,8 @@ pub fn Role(role: DBRole) -> Element {
             Badge {
                 class: "mr-2",
                 badge_color: BadgeColor::Neutral,
+                badge_style: BadgeStyle::Outline,
+                badge_size: BadgeSize::Sm,
                 "Collaborator"
             }
         ),


### PR DESCRIPTION
## Summary
- ensure tailwind includes small outline badge classes
- standardize badge style & size across web pages
- remove placeholder asset logic from build.rs

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: unable to run custom build command for `assets`)*

------
https://chatgpt.com/codex/tasks/task_e_68614b9a43788320aecdbcdb81946ee2