### PR TITLE
Fix embeddings context size usage

### DIFF
--- a/crates/db/queries/prompts.sql
+++ b/crates/db/queries/prompts.sql
@@ -1,6 +1,6 @@
 --: Prompt(image_icon_object_id?, temperature?, system_prompt?, api_key?, example1?, example2?, example3?, example4?)
 --: MyPrompt(image_icon_object_id?, api_key?)
---: SinglePrompt(temperature?, system_prompt?, embeddings_base_url?, embeddings_model?, embeddings_api_key?, api_key?, example1?, example2?, example3?, example4?)
+--: SinglePrompt(temperature?, system_prompt?, embeddings_base_url?, embeddings_model?, embeddings_api_key?, embeddings_context_size?, api_key?, example1?, example2?, example3?, example4?)
 
 --! update_image
 UPDATE 
@@ -148,9 +148,12 @@ SELECT
     (SELECT name FROM models WHERE id IN 
         (SELECT embeddings_model_id FROM datasets ds WHERE ds.id IN
         (SELECT dataset_id FROM prompt_dataset WHERE prompt_id = p.id LIMIT 1))) as embeddings_model,
-    (SELECT api_key FROM models WHERE id IN 
+    (SELECT api_key FROM models WHERE id IN
         (SELECT embeddings_model_id FROM datasets ds WHERE ds.id IN
         (SELECT dataset_id FROM prompt_dataset WHERE prompt_id = p.id LIMIT 1))) as embeddings_api_key,
+    (SELECT context_size FROM models WHERE id IN
+        (SELECT embeddings_model_id FROM datasets ds WHERE ds.id IN
+        (SELECT dataset_id FROM prompt_dataset WHERE prompt_id = p.id LIMIT 1))) as embeddings_context_size,
     p.model_id,
     p.category_id,
     p.name,

--- a/crates/integrations/tools/search_context.rs
+++ b/crates/integrations/tools/search_context.rs
@@ -85,7 +85,7 @@ async fn search_context(
         query,
         &base_url,
         &model,
-        prompt.model_context_size,
+        prompt.embeddings_context_size.unwrap_or(256),
         &Some(api_key),
     )
     .await

--- a/crates/llm-proxy/prompt.rs
+++ b/crates/llm-proxy/prompt.rs
@@ -231,7 +231,7 @@ async fn legacy_related_context(
             question,
             &embeddings_base_url,
             &embeddings_model,
-            prompt.model_context_size,
+            prompt.embeddings_context_size.unwrap_or(256),
             &prompt.embeddings_api_key,
         )
         .await


### PR DESCRIPTION
## Summary
- get embeddings model's context size when fetching prompts
- pass embeddings_context_size to `get_embeddings`
- default embeddings context size to 256

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`


------
https://chatgpt.com/codex/tasks/task_e_68637a4dfa00832085d632df98dc305d