### PR TITLE
Add TokenProvider trait for API tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "chrono",
  "db",
  "embeddings-api",
+ "futures",
  "futures-util",
  "oas3",
  "oauth2",
@@ -2218,6 +2219,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
 ]

--- a/crates/db/lib.rs
+++ b/crates/db/lib.rs
@@ -13,7 +13,13 @@ pub use queries::audit_trail::AuditTrail;
 pub use queries::automation_triggers::CronTrigger;
 pub use queries::categories::Category;
 pub use queries::chats::Chat;
-pub use queries::connections::{ApiKeyConnection, Oauth2Connection};
+pub use queries::connections::{
+    oauth2_connections_needing_refresh,
+    update_oauth2_connection,
+    ApiKeyConnection,
+    Oauth2Connection,
+    Oauth2RefreshCandidate,
+};
 pub use queries::conversations::{Conversation, ConversationContextSize};
 pub use queries::datasets::Dataset;
 pub use queries::document_pipelines::DocumentPipeline;

--- a/crates/db/queries/prompt_integrations.sql
+++ b/crates/db/queries/prompt_integrations.sql
@@ -1,5 +1,5 @@
 --: PromptIntegration()
---: PromptIntegrationWithConnection(api_connection_id?, oauth2_connection_id?,  definition?, bearer_token?)
+--: PromptIntegrationWithConnection(api_connection_id?, oauth2_connection_id?,  definition?, bearer_token?, refresh_token?, expires_at?)
 
 --! prompt_integrations : PromptIntegration
 SELECT
@@ -68,6 +68,8 @@ SELECT
         WHEN o2c.access_token IS NOT NULL THEN decrypt_text(o2c.access_token)
         ELSE NULL
     END AS bearer_token
+    , decrypt_text(o2c.refresh_token) AS refresh_token
+    , o2c.expires_at
 FROM prompt_integration pi
 JOIN integrations i ON pi.integration_id = i.id
 LEFT JOIN api_key_connections akc ON pi.api_connection_id = akc.id

--- a/crates/integrations/Cargo.toml
+++ b/crates/integrations/Cargo.toml
@@ -21,6 +21,9 @@ async-trait = { version = "0.1" }
 oas3 = "0.16.1"
 oauth2 = "5.0.0"
 reqwest = { version = "0", default-features = false, features = ["json", "rustls-tls", "stream"] }
+time = { version = "0.3", features = ["parsing", "formatting"] }
+# Used by tests
+futures = "0.3"
 
 # Used by the web tool to stream responses
 futures-util = "0.3"

--- a/crates/integrations/bionic_openapi.rs
+++ b/crates/integrations/bionic_openapi.rs
@@ -4,6 +4,7 @@
 //! extracting tool definitions and handling parameter parsing.
 
 use crate::tool::ToolInterface;
+use crate::token_providers::{OAuth2TokenProvider, StaticTokenProvider, TokenProvider};
 use db::queries::prompt_integrations::PromptIntegrationWithConnection;
 use oas3::{
     self,
@@ -388,7 +389,7 @@ impl BionicOpenAPI {
     /// Create tools from the OpenAPI specification
     pub fn create_tools(
         &self,
-        bearer_token: Option<String>,
+        token_provider: Option<Arc<dyn crate::token_providers::TokenProvider>>,
     ) -> Result<Vec<Arc<dyn ToolInterface>>, String> {
         let mut tools: Vec<Arc<dyn ToolInterface>> = Vec::new();
         let integration_tools = self.create_tool_definitions();
@@ -399,7 +400,6 @@ impl BionicOpenAPI {
 
         // Create tools for each tool definition
         for tool_def in integration_tools.tool_definitions {
-            // The function name is now the operation_id, so we use it directly
             let operation_id = tool_def.function.name.clone();
 
             let tool = crate::OpenApiTool::new(
@@ -407,8 +407,8 @@ impl BionicOpenAPI {
                 base_url.clone(),
                 self.spec.clone(),
                 operation_id,
-                bearer_token.clone(),
                 auth_header_name.clone(),
+                token_provider.clone(),
             );
             tools.push(Arc::new(tool));
         }
@@ -420,13 +420,43 @@ impl BionicOpenAPI {
 /// Create tools from a single integration
 pub fn create_tools_from_integration(
     integration: &PromptIntegrationWithConnection,
+    pool: Option<db::Pool>,
+    sub: Option<String>,
 ) -> Result<Vec<Arc<dyn ToolInterface>>, String> {
     if let Some(definition) = &integration.definition {
         let oas3 = oas3::from_json(definition.to_string())
             .map_err(|e| format!("Failed to parse OpenAPI spec: {}", e))?;
 
         let bionic_api = BionicOpenAPI::from_spec(oas3);
-        bionic_api.create_tools(integration.bearer_token.clone())
+        let token_provider: Option<Arc<dyn crate::token_providers::TokenProvider>> =
+            if let Some(conn_id) = integration.oauth2_connection_id {
+                if let Some(token) = &integration.bearer_token {
+                    if let (Some(pool), Some(sub)) = (pool, sub) {
+                        if let Some(config) = bionic_api.get_oauth2_config() {
+                            Some(Arc::new(crate::token_providers::OAuth2TokenProvider::new(
+                                pool,
+                                sub,
+                                conn_id,
+                                Some(token.clone()),
+                                integration.refresh_token.clone(),
+                                integration.expires_at,
+                                config,
+                            )) as Arc<dyn crate::token_providers::TokenProvider>)
+                        } else {
+                            Some(Arc::new(crate::token_providers::StaticTokenProvider::new(token.clone())) as Arc<_>)
+                        }
+                    } else {
+                        Some(Arc::new(crate::token_providers::StaticTokenProvider::new(token.clone())) as Arc<_>)
+                    }
+                } else {
+                    None
+                }
+            } else if let Some(token) = &integration.bearer_token {
+                Some(Arc::new(crate::token_providers::StaticTokenProvider::new(token.clone())) as Arc<_>)
+            } else {
+                None
+            };
+        bionic_api.create_tools(token_provider)
     } else {
         Err("Integration doesn't have a definition".to_string())
     }
@@ -435,11 +465,13 @@ pub fn create_tools_from_integration(
 /// Create tools from integrations
 pub async fn create_tools_from_integrations(
     integrations: Vec<PromptIntegrationWithConnection>,
+    pool: Option<db::Pool>,
+    sub: Option<String>,
 ) -> Vec<Arc<dyn ToolInterface>> {
     let mut tools: Vec<Arc<dyn ToolInterface>> = Vec::new();
 
     for integration in integrations {
-        match create_tools_from_integration(&integration) {
+        match create_tools_from_integration(&integration, pool.clone(), sub.clone()) {
             Ok(integration_tools) => {
                 tools.extend(integration_tools);
             }

--- a/crates/integrations/lib.rs
+++ b/crates/integrations/lib.rs
@@ -7,6 +7,7 @@ pub mod tool;
 pub mod tool_executor;
 pub mod tool_registry;
 pub mod tools;
+pub mod token_providers;
 
 #[cfg(test)]
 mod test_async;
@@ -30,3 +31,4 @@ pub use tool_registry::{
     get_chat_tools_user_selected, get_integrations, get_tools, IntegrationTool, ToolScope,
 };
 pub use tools::open_api_tool::OpenApiTool;
+pub use token_providers::{OAuth2TokenProvider, StaticTokenProvider, TokenProvider};

--- a/crates/integrations/token_providers.rs
+++ b/crates/integrations/token_providers.rs
@@ -1,0 +1,158 @@
+use async_trait::async_trait;
+use db::{self, Pool};
+use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RefreshToken, TokenResponse, TokenUrl};
+use reqwest::Client;
+use time::{Duration, OffsetDateTime};
+use crate::bionic_openapi::OAuth2Config;
+
+#[async_trait]
+pub trait TokenProvider: Send + Sync {
+    async fn token(&self) -> Option<String>;
+}
+
+pub struct StaticTokenProvider {
+    token: String,
+}
+
+impl StaticTokenProvider {
+    pub fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+#[async_trait]
+impl TokenProvider for StaticTokenProvider {
+    async fn token(&self) -> Option<String> {
+        Some(self.token.clone())
+    }
+}
+
+pub struct OAuth2TokenProvider {
+    pool: Pool,
+    sub: String,
+    connection_id: i32,
+    client: Client,
+    token: tokio::sync::Mutex<Option<String>>,
+    refresh_token: tokio::sync::Mutex<Option<String>>,
+    expires_at: tokio::sync::Mutex<Option<OffsetDateTime>>,
+    config: OAuth2Config,
+}
+
+impl OAuth2TokenProvider {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        pool: Pool,
+        sub: String,
+        connection_id: i32,
+        token: Option<String>,
+        refresh_token: Option<String>,
+        expires_at: Option<OffsetDateTime>,
+        config: OAuth2Config,
+    ) -> Self {
+        Self {
+            pool,
+            sub,
+            connection_id,
+            client: Client::new(),
+            token: tokio::sync::Mutex::new(token),
+            refresh_token: tokio::sync::Mutex::new(refresh_token),
+            expires_at: tokio::sync::Mutex::new(expires_at),
+            config,
+        }
+    }
+
+    async fn refresh_if_needed(&self) {
+        let mut token_guard = self.token.lock().await;
+        let mut refresh_guard = self.refresh_token.lock().await;
+        let mut expiry_guard = self.expires_at.lock().await;
+
+        if expiry_guard
+            .as_ref()
+            .is_some_and(|e| *e > OffsetDateTime::now_utc())
+        {
+            return;
+        }
+
+        let Some(refresh_token) = refresh_guard.as_ref() else { return; };
+
+        let mut client = match self.pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to get db client: {}", e);
+                return;
+            }
+        };
+        let transaction = match client.transaction().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("Failed to start transaction: {}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = db::authz::set_row_level_security_user_id(&transaction, self.sub.clone()).await {
+            tracing::error!("Failed to set RLS: {}", e);
+            return;
+        }
+
+        let oauth_client = match db::queries::oauth_clients::oauth_client_by_provider_url()
+            .bind(&transaction, &self.config.authorization_url)
+            .one()
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to load oauth client: {}", e);
+                return;
+            }
+        };
+
+        let client = BasicClient::new(ClientId::new(oauth_client.client_id))
+            .set_client_secret(ClientSecret::new(oauth_client.client_secret))
+            .set_auth_uri(AuthUrl::new(self.config.authorization_url.clone()).unwrap())
+            .set_token_uri(TokenUrl::new(self.config.token_url.clone()).unwrap());
+
+        let token = match client
+            .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
+            .request_async(&self.client)
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("Failed to refresh token: {}", e);
+                return;
+            }
+        };
+
+        let new_token = token.access_token().secret().to_string();
+        let new_refresh = token.refresh_token().map(|t| t.secret().to_string());
+        let new_expiry = token
+            .expires_in()
+            .map(|dur| OffsetDateTime::now_utc() + Duration::seconds(dur.as_secs() as i64));
+
+        if let Err(e) = db::queries::connections::update_oauth2_connection()
+            .bind(&transaction, &new_token, &new_refresh.as_deref(), &new_expiry, &self.connection_id)
+            .await
+        {
+            tracing::error!("Failed to update connection: {}", e);
+            return;
+        }
+        if let Err(e) = transaction.commit().await {
+            tracing::error!("Failed to commit token update: {}", e);
+            return;
+        }
+
+        *token_guard = Some(new_token);
+        *refresh_guard = new_refresh;
+        *expiry_guard = new_expiry;
+    }
+}
+
+#[async_trait]
+impl TokenProvider for OAuth2TokenProvider {
+    async fn token(&self) -> Option<String> {
+        self.refresh_if_needed().await;
+        self.token.lock().await.clone()
+    }
+}
+

--- a/crates/integrations/tool_executor.rs
+++ b/crates/integrations/tool_executor.rs
@@ -33,7 +33,12 @@ async fn get_external_integration_tools(
         external_integrations.len()
     );
 
-    let tools = create_tools_from_integrations(external_integrations).await;
+    let tools = create_tools_from_integrations(
+        external_integrations,
+        Some(pool.clone()),
+        Some(sub.clone()),
+    )
+    .await;
     debug!("Created {} external integration tools", tools.len());
 
     Ok(tools)

--- a/crates/llm-proxy/prompt.rs
+++ b/crates/llm-proxy/prompt.rs
@@ -72,7 +72,7 @@ pub async fn get_prompt_integration_tools(
         })?;
 
     // Create tools from the integrations
-    let external_tools = create_tools_from_integrations(prompt_integrations).await;
+    let external_tools = create_tools_from_integrations(prompt_integrations, None, None).await;
 
     let mut filtered_tools: Vec<BionicToolDefinition> = external_tools
         .into_iter()


### PR DESCRIPTION
## Summary
- extract `TokenProvider`, `StaticTokenProvider`, and `OAuth2TokenProvider` into `token_providers.rs`
- update `OpenApiTool` and `BionicOpenAPI` to use the new module
- re-export token providers from the `integrations` crate

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`


------
https://chatgpt.com/codex/tasks/task_e_686364d12258832080d15bb3b981b79a