### PR TITLE
Add system info page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,6 +5367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "toml 0.8.19",
  "validator",
 ]
 

--- a/crates/web-pages/Cargo.toml
+++ b/crates/web-pages/Cargo.toml
@@ -24,3 +24,4 @@ comrak = { version = "0.39.0", features = ["shortcodes"] }
 time = "0.3.36"
 validator = { version = "0.20.0", features = ["derive"] }
 oas3 = "0.16.1"
+toml = "0.8"

--- a/crates/web-pages/app_layout.rs
+++ b/crates/web-pages/app_layout.rs
@@ -199,6 +199,13 @@ pub fn Layout(props: LayoutProps) -> Element {
                                     icon: nav_api_keys_svg.name,
                                     title: "OAuth Clients"
                                 }
+                                NavItem {
+                                    id: SideBar::Licence.to_string(),
+                                    selected_item_id: props.selected_item.to_string(),
+                                    href: super::routes::licence::Index { team_id: props.team_id },
+                                    icon: nav_audit_svg.name,
+                                    title: "System Info"
+                                }
                             }
                         )
                     }

--- a/crates/web-pages/lib.rs
+++ b/crates/web-pages/lib.rs
@@ -18,6 +18,7 @@ pub mod menu;
 pub mod models;
 pub mod my_assistants;
 pub mod oauth_clients;
+pub mod licence;
 pub mod pipelines;
 pub mod profile;
 pub mod profile_popup;

--- a/crates/web-pages/licence/mod.rs
+++ b/crates/web-pages/licence/mod.rs
@@ -1,0 +1,1 @@
+pub mod page;

--- a/crates/web-pages/licence/page.rs
+++ b/crates/web-pages/licence/page.rs
@@ -1,0 +1,104 @@
+#![allow(non_snake_case)]
+use crate::app_layout::{Layout, SideBar};
+use crate::components::card_item::CardItem;
+use assets::files::*;
+use daisy_rsx::*;
+use db::{authz::Rbac, customer_keys, Licence};
+use dioxus::prelude::*;
+use toml::Value;
+
+fn get_version() -> String {
+    let cargo_toml = include_str!("../../k8s-operator/Cargo.toml");
+    let value: Value = cargo_toml.parse().expect("valid Cargo.toml");
+    value
+        .get("package")
+        .and_then(|pkg| pkg.get("version"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn page(team_id: i32, rbac: Rbac) -> String {
+    let licence = Licence::global();
+    let encryption = if customer_keys::get_customer_key().is_some() { "Enabled" } else { "Disabled" };
+    let version = get_version();
+    let rag_mode = if std::env::var("AGENTIC_RAG").is_ok() { "Agentic RAG" } else { "Contextual RAG" };
+    let automations = if std::env::var("AUTOMATIONS_FEATURE").is_ok() { "Enabled" } else { "Disabled" };
+
+    let page = rsx! {
+        Layout {
+            section_class: "p-4",
+            selected_item: SideBar::Licence,
+            team_id: team_id,
+            rbac: rbac,
+            title: "System Info",
+            header: rsx!(
+                Breadcrumb { items: vec![BreadcrumbItem { text: "System Info".into(), href: None }] }
+            ),
+            div {
+                class: "p-4 max-w-3xl w-full mx-auto space-y-4",
+                CardItem {
+                    class: None,
+                    popover_target: None,
+                    clickable_link: None,
+                    image_src: Some(bionic_logo_svg.name.to_string()),
+                    avatar_name: None,
+                    title: "Licence".to_string(),
+                    description: Some(rsx!( span { "Users: {licence.user_count}, Domain: {licence.hostname_url}, Expires: {licence.end_date.date()}" } )),
+                    footer: None,
+                    count_labels: vec![],
+                    action: None,
+                }
+                CardItem {
+                    class: None,
+                    popover_target: None,
+                    clickable_link: None,
+                    image_src: Some(nav_audit_svg.name.to_string()),
+                    avatar_name: None,
+                    title: "Runtime Encryption".to_string(),
+                    description: Some(rsx!( span { "{encryption}" } )),
+                    footer: None,
+                    count_labels: vec![],
+                    action: None,
+                }
+                CardItem {
+                    class: None,
+                    popover_target: None,
+                    clickable_link: None,
+                    image_src: Some(nav_phonebook_svg.name.to_string()),
+                    avatar_name: None,
+                    title: "Version".to_string(),
+                    description: Some(rsx!( span { "{version}" } )),
+                    footer: None,
+                    count_labels: vec![],
+                    action: None,
+                }
+                CardItem {
+                    class: None,
+                    popover_target: None,
+                    clickable_link: None,
+                    image_src: Some(nav_service_requests_svg.name.to_string()),
+                    avatar_name: None,
+                    title: "RAG Mode".to_string(),
+                    description: Some(rsx!( span { "{rag_mode}" } )),
+                    footer: None,
+                    count_labels: vec![],
+                    action: None,
+                }
+                CardItem {
+                    class: None,
+                    popover_target: None,
+                    clickable_link: None,
+                    image_src: Some(nav_automations_svg.name.to_string()),
+                    avatar_name: None,
+                    title: "Automations".to_string(),
+                    description: Some(rsx!( span { "{automations}" } )),
+                    footer: None,
+                    count_labels: vec![],
+                    action: None,
+                }
+            }
+        }
+    };
+    crate::render(page)
+}

--- a/crates/web-pages/routes.rs
+++ b/crates/web-pages/routes.rs
@@ -662,3 +662,14 @@ pub mod oauth_clients {
         pub id: i32,
     }
 }
+
+pub mod licence {
+    use axum_extra::routing::TypedPath;
+    use serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/app/team/{team_id}/licence")]
+    pub struct Index {
+        pub team_id: i32,
+    }
+}

--- a/crates/web-server/handlers/licence.rs
+++ b/crates/web-server/handlers/licence.rs
@@ -1,0 +1,29 @@
+use crate::{CustomError, Jwt};
+use axum::extract::Extension;
+use axum::response::Html;
+use axum_extra::routing::RouterExt;
+use axum::Router;
+use db::{authz, Pool};
+use web_pages::{licence, routes::licence::Index};
+
+pub fn routes() -> Router {
+    Router::new().typed_get(loader)
+}
+
+pub async fn loader(
+    Index { team_id }: Index,
+    current_user: Jwt,
+    Extension(pool): Extension<Pool>,
+) -> Result<Html<String>, CustomError> {
+    let mut client = pool.get().await?;
+    let transaction = client.transaction().await?;
+    let rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
+
+    if !rbac.is_sys_admin {
+        return Err(CustomError::Authorization);
+    }
+
+    let html = licence::page::page(team_id, rbac);
+
+    Ok(Html(html))
+}

--- a/crates/web-server/handlers/mod.rs
+++ b/crates/web-server/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod models;
 pub mod my_assistants;
 pub mod oauth2;
 pub mod oauth_clients;
+pub mod licence;
 pub mod oidc_endpoint;
 pub mod pipelines;
 pub mod profile;

--- a/crates/web-server/main.rs
+++ b/crates/web-server/main.rs
@@ -99,6 +99,7 @@ async fn main() {
         .merge(handlers::assistants::routes())
         .merge(handlers::my_assistants::routes())
         .merge(handlers::rate_limits::routes())
+        .merge(handlers::licence::routes())
         .merge(handlers::team::routes())
         .merge(handlers::teams::routes())
         .layer(Extension(config.clone()))


### PR DESCRIPTION
## Summary
- add a new System Info page under sys admin
- show licence, encryption, software version, RAG mode and automations status
- expose the page via new `/licence` route and handler
- display the page in the sidebar

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_686655435850832086dd804c7ba13fed