### PR TITLE
Enable Turbo Frame for integration cards

### DIFF
--- a/crates/web-assets/typescript/components/clickable-card.ts
+++ b/crates/web-assets/typescript/components/clickable-card.ts
@@ -15,10 +15,14 @@ export const clickableCard = () => {
 
             const url = el.getAttribute('data-clickable-link');
             if (url) {
-                // Use Turbo for navigation if available
+                const frame = el.getAttribute('data-turbo-frame');
                 const turbo = (window as any).Turbo;
                 if (turbo?.visit) {
-                    turbo.visit(url);
+                    if (frame) {
+                        turbo.visit(url, { frame });
+                    } else {
+                        turbo.visit(url);
+                    }
                 } else {
                     window.location.href = url;
                 }

--- a/crates/web-pages/components/card_item.rs
+++ b/crates/web-pages/components/card_item.rs
@@ -13,6 +13,7 @@ pub struct CardItemProps {
     pub class: Option<String>,
     pub popover_target: Option<String>,
     pub clickable_link: Option<String>,
+    pub turbo_frame: Option<String>,
     pub image_src: Option<String>,
     pub avatar_name: Option<String>,
 
@@ -38,6 +39,9 @@ pub fn CardItem(props: CardItemProps) -> Element {
             },
             popover_target: props.popover_target.clone(),
             clickable_link: props.clickable_link.clone(),
+            if let Some(frame) = props.turbo_frame.clone() {
+                "data-turbo-frame": "{frame}",
+            }
             div {
                 class: "flex flex-col justify-center",
                 if let Some(src) = props.image_src.clone() {

--- a/crates/web-pages/integrations/integration_card.rs
+++ b/crates/web-pages/integrations/integration_card.rs
@@ -31,6 +31,7 @@ pub fn IntegrationCard(integration: IntegrationSummary, team_id: i32) -> Element
         CardItem {
             class: Some("cursor-pointer hover:bg-base-200 w-full".into()),
             clickable_link: crate::routes::integrations::View { team_id, id: integration.id }.to_string(),
+            turbo_frame: Some("main-content".into()),
             image_src: Some(integration.openapi.get_logo_url()),
             title: integration.openapi.get_title().to_string(),
             description: if description.is_empty() { None } else { Some(rsx!(span { "{description}" })) },


### PR DESCRIPTION
## Summary
- add optional `turbo_frame` to `CardItemProps`
- pass the frame to the `Card` element when provided
- create integration cards targeting the `main-content` frame
- adjust clickable card script to use `data-turbo-frame`

## Testing
- `npm run release --prefix crates/web-assets`
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: compilation took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68665b39914c8320b2e219d3b7ab3b94