### PR TITLE
Fix Keycloak network policy

### DIFF
--- a/crates/k8s-operator/src/services/bionic.rs
+++ b/crates/k8s-operator/src/services/bionic.rs
@@ -22,6 +22,8 @@ static SMTP_SECRETS: &str = "smtp-secrets";
 static LICENCE: &str = "LICENCE";
 static LICENCE_SECRET: &str = "bionic-gpt-licence";
 
+pub const BIONIC_NAME: &str = "bionic-gpt";
+
 // The web user interface
 pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result<(), Error> {
     let mut env = vec![
@@ -170,7 +172,7 @@ pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result
     deployment::deployment(
         client.clone(),
         deployment::ServiceDeployment {
-            name: "bionic-gpt".to_string(),
+            name: BIONIC_NAME.to_string(),
             image_name,
             replicas: spec.replicas,
             port: 7903,
@@ -266,14 +268,14 @@ fn lower_dash(s: &str) -> String {
 pub async fn delete(client: Client, namespace: &str) -> Result<(), Error> {
     // Remove deployments
     let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
-    if api.get("bionic-gpt").await.is_ok() {
-        api.delete("bionic-gpt", &DeleteParams::default()).await?;
+    if api.get(BIONIC_NAME).await.is_ok() {
+        api.delete(BIONIC_NAME, &DeleteParams::default()).await?;
     }
 
     // Remove services
     let api: Api<Service> = Api::namespaced(client, namespace);
-    if api.get("bionic-gpt").await.is_ok() {
-        api.delete("bionic-gpt", &DeleteParams::default()).await?;
+    if api.get(BIONIC_NAME).await.is_ok() {
+        api.delete(BIONIC_NAME, &DeleteParams::default()).await?;
     }
     Ok(())
 }

--- a/crates/k8s-operator/src/services/database.rs
+++ b/crates/k8s-operator/src/services/database.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::error::Error;
+use crate::services::bionic::BIONIC_NAME;
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{DeleteParams, ObjectMeta};
 use kube::CustomResource;
@@ -81,7 +82,7 @@ pub async fn deploy(
             instances: 1,
             bootstrap: BootstrapSpec {
                 initdb: InitDBSpec {
-                    database: "bionic-gpt".to_string(),
+                    database: BIONIC_NAME.to_string(),
                     owner: "db-owner".to_string(),
                     secret: SecretSpec {
                         name: "db-owner".to_string(),

--- a/crates/k8s-operator/src/services/network_policy.rs
+++ b/crates/k8s-operator/src/services/network_policy.rs
@@ -1,3 +1,4 @@
+use super::{bionic::BIONIC_NAME, keycloak::KEYCLOAK_NAME};
 use crate::error::Error;
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{Patch, PatchParams};
@@ -28,7 +29,7 @@ pub async fn default_deny(client: Client, name: &str, namespace: &str) -> Result
     }]);
 
     // Egress: allow DNS + namespace-local traffic
-    let egress = if name == "bionic-gpt" {
+    let egress = if name == BIONIC_NAME || name == KEYCLOAK_NAME {
         json!([
             { "to": [{ "ipBlock": { "cidr": "0.0.0.0/0" } }] }
         ])

--- a/crates/k8s-operator/src/services/oauth2_proxy.rs
+++ b/crates/k8s-operator/src/services/oauth2_proxy.rs
@@ -1,6 +1,7 @@
 use super::deployment;
 use crate::error::Error;
 use crate::operator::crd::BionicSpec;
+use crate::services::bionic::BIONIC_NAME;
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Secret, Service};
 use kube::api::{DeleteParams, PostParams};
@@ -126,10 +127,10 @@ async fn oauthproxy_secret(namespace: &str, spec: BionicSpec, client: Client) ->
                 "namespace": namespace
             },
             "stringData": {
-                "client-id": "bionic-gpt",
+                "client-id": BIONIC_NAME,
                 "client-secret": "69b26b08-12fe-48a2-85f0-6ab223f45777",
                 "redirect-uri": format!("{}/oauth2/callback", spec.hostname_url),
-                "issuer-url": "http://keycloak:7910/oidc/realms/bionic-gpt",
+                "issuer-url": format!("http://keycloak:7910/oidc/realms/{}", BIONIC_NAME),
                 "cookie-secret": rand_base64()
             }
         }))?;


### PR DESCRIPTION
## Summary
- allow Keycloak pods to make external network connections
- add `BIONIC_NAME` constant
- apply constant for database, network policy and oauth2 proxy

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6867705e9cc48320a6a95224f1e90ddf