### PR TITLE
Make console textarea required

### DIFF
--- a/crates/web-pages/console/prompt_form.rs
+++ b/crates/web-pages/console/prompt_form.rs
@@ -58,7 +58,8 @@ pub fn Form(
                             rows: "1",
                             placeholder: "Ask a question...",
                             name: "message",
-                            disabled: lock_console
+                            disabled: lock_console,
+                            required: true
                         }
                     }
                     div {


### PR DESCRIPTION
## Summary
- enforce `required` attribute on the console prompt textarea so empty submissions are prevented

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6868ee6a2f608320b86a0f80d16e5bda