### PR TITLE
Fix sidebar highlight when navigating via browser history

### DIFF
--- a/crates/web-assets/typescript/layout/update-sidebar.ts
+++ b/crates/web-assets/typescript/layout/update-sidebar.ts
@@ -1,16 +1,21 @@
 // When using turbo frames side nav does not get updated.
 export const updateSidebar = () => {
-    // Persist a form to local storage.
-    document.querySelectorAll('a[data-turbo-frame="main-content"]').forEach((link) => {
-        link.addEventListener("click", function() {
+    const links = document.querySelectorAll<HTMLAnchorElement>('a[data-turbo-frame="main-content"]');
 
-            // Remove all active
-            document.querySelectorAll('a[data-turbo-frame="main-content"]').forEach((link) => {
-                link.classList.remove('menu-active')
-            })
+    // When a menu item is clicked make it active
+    links.forEach((link) => {
+        link.addEventListener('click', function () {
+            links.forEach((l) => l.classList.remove('menu-active'));
+            link.classList.add('menu-active');
+        }, { once: true });
+    });
 
-            // Set this one
-            link.classList.add('menu-active')
-        }, {once : true});
-    })
-}
+    // Highlight the menu item that matches the current path
+    links.forEach((link) => {
+        const url = new URL(link.href, window.location.origin);
+        if (url.pathname === window.location.pathname) {
+            links.forEach((l) => l.classList.remove('menu-active'));
+            link.classList.add('menu-active');
+        }
+    });
+};


### PR DESCRIPTION
## Summary
- update `update-sidebar.ts` to set menu-active class based on current URL

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6868eee88c088320addde1c1a652bf6a