### PR TITLE
Use env VERSION in licence page

### DIFF
--- a/crates/web-pages/licence/page.rs
+++ b/crates/web-pages/licence/page.rs
@@ -8,6 +8,10 @@ use dioxus::prelude::*;
 use toml::Value;
 
 fn get_version() -> String {
+    if let Ok(ver) = std::env::var("VERSION") {
+        return ver;
+    }
+
     let cargo_toml = include_str!("../../k8s-operator/Cargo.toml");
     let value: Value = cargo_toml.parse().expect("valid Cargo.toml");
     value


### PR DESCRIPTION
## Summary
- read VERSION env var for system info page

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6868f2e2750c8320a17615fbbdfc179c