### PR TITLE
Add offline flag to OAuth2 request

### DIFF
--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -86,7 +86,9 @@ pub async fn connect_loader(
     // Generate the authorization URL to which we'll redirect the user.
     let mut auth_request = client
         .authorize_url(CsrfToken::new_random)
-        .set_pkce_challenge(pkce_code_challenge);
+        .set_pkce_challenge(pkce_code_challenge)
+        .add_extra_param("access_type", "offline")
+        .add_extra_param("prompt", "consent");
 
     // Add scopes from the OAuth2 configuration
     for scope in oauth2_config.scopes {


### PR DESCRIPTION
## Summary
- request offline access by adding `access_type` and `prompt` parameters when building OAuth2 authorization URL

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine` *(fails: failed to run custom build command for `db`)*

------
https://chatgpt.com/codex/tasks/task_e_686f774bb7b88320add7de4ba35e7236