### PR TITLE
Fix guard sanitization of system messages

### DIFF
--- a/crates/llm-proxy/moderation.rs
+++ b/crates/llm-proxy/moderation.rs
@@ -32,6 +32,10 @@ pub fn strip_tool_data(messages: &[ChatCompletionMessage]) -> Vec<ChatCompletion
                 return None;
             }
 
+            if m.role == ChatCompletionMessageRole::System {
+                m.role = ChatCompletionMessageRole::User;
+            }
+
             Some(m)
         })
         .collect()

--- a/crates/llm-proxy/tests.rs
+++ b/crates/llm-proxy/tests.rs
@@ -479,3 +479,22 @@ fn test_strip_tool_data_removes_tool_messages() {
     assert!(sanitized[0].tool_calls.is_none());
     assert!(sanitized[0].tool_call_id.is_none());
 }
+
+#[test]
+fn test_strip_tool_data_changes_system_to_user() {
+    use openai_api::ChatCompletionMessageRole;
+
+    let messages = vec![ChatCompletionMessage {
+        role: ChatCompletionMessageRole::System,
+        content: Some("hi".to_string()),
+        tool_call_id: None,
+        tool_calls: None,
+        name: None,
+    }];
+
+    let sanitized = strip_tool_data(&messages);
+
+    assert_eq!(sanitized.len(), 1);
+    assert_eq!(sanitized[0].role, ChatCompletionMessageRole::User);
+    assert_eq!(sanitized[0].content, Some("hi".to_string()));
+}


### PR DESCRIPTION
## Summary
- treat system messages as user messages in the moderation sanitizer
- verify sanitization behaviour with a new unit test

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_68724722c9388320910483b7f201750c