### PR TITLE
Enhance team card interactions

### DIFF
--- a/crates/web-pages/team/members.rs
+++ b/crates/web-pages/team/members.rs
@@ -30,11 +30,13 @@ pub fn page(
                         href: None
                     }]
                 }
-                Button {
-                    prefix_image_src: "{button_plus_svg.name}",
-                    popover_target: "create-invite-form",
-                    button_scheme: ButtonScheme::Primary,
-                    "Invite New Team Member"
+                if rbac.can_make_invitations() && user.first_name.is_some() && team.name.is_some() {
+                    Button {
+                        prefix_image_src: "{button_plus_svg.name}",
+                        popover_target: "create-invite-form",
+                        button_scheme: ButtonScheme::Primary,
+                        "Invite New Team Member"
+                    }
                 }
             ),
             div {
@@ -132,7 +134,8 @@ pub fn page(
 
                 // Form to set he org name
                 super::team_name_form::TeamNameForm {
-                    submit_action: crate::routes::team::SetName{team_id:team.id}.to_string()
+                    submit_action: crate::routes::team::SetName{team_id:team.id}.to_string(),
+                    trigger_id: "set-name-drawer".to_string(),
                 }
             }
         }

--- a/crates/web-pages/team/team_name_form.rs
+++ b/crates/web-pages/team/team_name_form.rs
@@ -3,14 +3,14 @@ use daisy_rsx::*;
 use dioxus::prelude::*;
 
 #[component]
-pub fn TeamNameForm(submit_action: String) -> Element {
+pub fn TeamNameForm(submit_action: String, trigger_id: String) -> Element {
     rsx! {
         form {
             method: "post",
             "data-turbo-frame": "_top",
             action: "{submit_action}",
             Modal {
-                trigger_id: "set-name-drawer",
+                trigger_id: &trigger_id,
                 ModalBody {
                     h3 {
                         class: "font-bold text-lg mb-4",

--- a/crates/web-pages/teams/mod.rs
+++ b/crates/web-pages/teams/mod.rs
@@ -2,3 +2,4 @@ pub mod accept_invitation;
 pub mod invite_card;
 pub mod page;
 pub mod team_card;
+pub use page::TeamSummary;

--- a/crates/web-pages/teams/page.rs
+++ b/crates/web-pages/teams/page.rs
@@ -8,10 +8,16 @@ use db::authz::Rbac;
 use db::{InviteSummary, TeamOwner};
 use dioxus::prelude::*;
 
+#[derive(Clone)]
+pub struct TeamSummary {
+    pub team: TeamOwner,
+    pub member_count: usize,
+}
+
 pub fn page(
     rbac: Rbac,
     team_id: i32,
-    teams: Vec<TeamOwner>,
+    teams: Vec<TeamSummary>,
     invites: Vec<InviteSummary>,
     current_user_email: String,
 ) -> String {
@@ -49,9 +55,10 @@ pub fn page(
 
                 div {
                     class: "mt-5 space-y-2",
-                    for team in &teams {
+                    for summary in &teams {
                         TeamCard {
-                            team: team.clone(),
+                            team: summary.team.clone(),
+                            member_count: summary.member_count,
                             current_team_id: team_id,
                             teams_len: teams.len(),
                             current_user_email: current_user_email.clone(),
@@ -83,15 +90,15 @@ pub fn page(
                 }
                 }
 
-                for team in teams {
+                for summary in teams {
                     ConfirmModal {
-                        action: crate::routes::teams::Delete {team_id: team.id}.to_string(),
-                        trigger_id: format!("delete-trigger-{}", team.id),
+                        action: crate::routes::teams::Delete {team_id: summary.team.id}.to_string(),
+                        trigger_id: format!("delete-trigger-{}", summary.team.id),
                         submit_label: "Delete".to_string(),
                         heading: "Delete this Team?".to_string(),
                         warning: "Are you sure you want to delete this Team?".to_string(),
                         hidden_fields: vec![
-                            ("team_id".into(), team.id.to_string()),
+                            ("team_id".into(), summary.team.id.to_string()),
                         ],
                     }
                 }

--- a/crates/web-pages/teams/team_card.rs
+++ b/crates/web-pages/teams/team_card.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use crate::components::card_item::{CardItem, CountLabel};
+use crate::team::team_name_form::TeamNameForm;
 use daisy_rsx::*;
 use db::TeamOwner;
 use dioxus::prelude::*;
@@ -6,6 +8,7 @@ use dioxus::prelude::*;
 #[derive(Props, Clone, PartialEq)]
 pub struct TeamCardProps {
     pub team: TeamOwner,
+    pub member_count: usize,
     pub current_team_id: i32,
     pub teams_len: usize,
     pub current_user_email: String,
@@ -18,30 +21,27 @@ pub fn TeamCard(props: TeamCardProps) -> Element {
         .team_name
         .clone()
         .unwrap_or_else(|| "Name Not Set".to_string());
+    let edit_trigger = format!("edit-team-name-{}", props.team.id);
     rsx!(
-        Card {
-            class: "p-3 flex flex-row justify-between",
-            div {
-                class: "flex flex-row items-center",
-                Avatar {
-                    avatar_size: AvatarSize::Medium,
-                    avatar_type: AvatarType::Team,
-                    name: "{name}"
-                }
-                div {
-                    class: "ml-4 flex flex-col",
-                    h2 {
-                        class: "font-semibold text-base mb-1",
-                        "{name}"
+        CardItem {
+            class: Some("cursor-pointer hover:bg-base-200 w-full".into()),
+            clickable_link: Some(crate::routes::team::Index { team_id: props.team.id }.to_string()),
+            popover_target: None,
+            image_src: None,
+            avatar_name: Some(name.clone()),
+            title: name.clone(),
+            description: Some(rsx!(span { "{props.team.team_owner}" })),
+            footer: None,
+            count_labels: vec![CountLabel { count: props.member_count, label: "Member".into() }],
+            action: Some(rsx!(
+                if props.team.team_owner == props.current_user_email && props.teams_len > 1 {
+                    DropDown {
+                        direction: Direction::Left,
+                        button_text: "...",
+                        DropDownLink { popover_target: edit_trigger.clone(), href: "#", target: "_top", "Edit Name" }
+                        DropDownLink { popover_target: format!("delete-trigger-{}", props.team.id), href: "#", target: "_top", "Delete Team" }
                     }
-                    p {
-                        class: "text-sm text-base-content/70",
-                        "{props.team.team_owner}"
-                    }
                 }
-            }
-            div {
-                class: "flex flex-row items-center ml-4 gap-2",
                 if props.team.id != props.current_team_id {
                     Button {
                         button_type: ButtonType::Link,
@@ -49,25 +49,15 @@ pub fn TeamCard(props: TeamCardProps) -> Element {
                         href: crate::routes::teams::Switch { team_id: props.team.id }.to_string(),
                         button_scheme: ButtonScheme::Info,
                         button_size: ButtonSize::Small,
-                        "Switch to this Team"
+                        "Switch"
                     }
                 }
-                if props.team.team_owner == props.current_user_email && props.teams_len > 1 {
-                    div {
-                        class: "flex flex-col justify-center",
-                        DropDown {
-                            direction: Direction::Left,
-                            button_text: "...",
-                            DropDownLink {
-                                popover_target: format!("delete-trigger-{}", props.team.id),
-                                href: "#",
-                                target: "_top",
-                                "Delete Team"
-                            }
-                        }
-                    }
-                }
-            }
+            )),
+        }
+
+        TeamNameForm {
+            submit_action: crate::routes::team::SetName { team_id: props.team.id }.to_string(),
+            trigger_id: edit_trigger,
         }
     )
 }

--- a/crates/web-server/handlers/teams/switch.rs
+++ b/crates/web-server/handlers/teams/switch.rs
@@ -21,10 +21,22 @@ pub async fn switch(
         .one()
         .await?;
 
-    let teams = queries::teams::get_teams()
+    let raw_teams = queries::teams::get_teams()
         .bind(&transaction, &rbac.user_id)
         .all()
         .await?;
+
+    let mut teams = Vec::new();
+    for team in raw_teams {
+        let members = queries::teams::get_users()
+            .bind(&transaction, &team.id)
+            .all()
+            .await?;
+        teams.push(teams::TeamSummary {
+            team,
+            member_count: members.len(),
+        });
+    }
 
     let invites = queries::invitations::get_by_user()
         .bind(&transaction)


### PR DESCRIPTION
## Summary
- show invite button conditionally on team member page
- extend TeamNameForm with a trigger ID prop
- update team card to show member counts and allow editing the team name
- pass member counts through team pages
- compute member counts server-side

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_687257a462ec83208d2e0d9141b6e699