### PR TITLE
Switch dataset and document pages to card layout

### DIFF
--- a/crates/web-pages/datasets/dataset_card.rs
+++ b/crates/web-pages/datasets/dataset_card.rs
@@ -1,0 +1,41 @@
+#![allow(non_snake_case)]
+use crate::assistants::visibility::VisLabel;
+use crate::components::card_item::{CardItem, CountLabel};
+use daisy_rsx::*;
+use db::authz::Rbac;
+use db::queries::datasets::Dataset;
+use dioxus::prelude::*;
+
+#[component]
+pub fn DatasetCard(team_id: i32, rbac: Rbac, dataset: Dataset) -> Element {
+    rsx!(CardItem {
+        class: Some("cursor-pointer hover:bg-base-200 w-full".into()),
+        clickable_link: crate::routes::documents::Index {
+            team_id,
+            dataset_id: dataset.id
+        }
+        .to_string(),
+        title: dataset.name.clone(),
+        description: None,
+        footer: None,
+        count_labels: vec![CountLabel {
+            count: dataset.count as usize,
+            label: "Document".into()
+        }],
+        action: Some(rsx!(
+            div {
+                class: "flex gap-2",
+                VisLabel { visibility: dataset.visibility }
+                DropDown {
+                    direction: Direction::Left,
+                    button_text: "...",
+                    DropDownLink { href: crate::routes::documents::Index{team_id, dataset_id: dataset.id}.to_string(), target: "_top", "View" }
+                    if rbac.can_edit_dataset(&dataset) {
+                        DropDownLink { popover_target: format!("edit-trigger-{}-{}", dataset.id, team_id), href: "#", target: "_top", "Edit" }
+                    }
+                    DropDownLink { popover_target: format!("delete-trigger-{}-{}", dataset.id, team_id), href: "#", target: "_top", "Delete" }
+                }
+            }
+        )),
+    })
+}

--- a/crates/web-pages/datasets/mod.rs
+++ b/crates/web-pages/datasets/mod.rs
@@ -1,2 +1,3 @@
+pub mod dataset_card;
 pub mod page;
 pub mod upsert;

--- a/crates/web-pages/datasets/page.rs
+++ b/crates/web-pages/datasets/page.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::dataset_card::DatasetCard;
 use crate::app_layout::Layout;
 use crate::app_layout::SideBar;
 use crate::components::confirm_modal::ConfirmModal;
@@ -51,92 +52,12 @@ pub fn page(
                 }
 
                 if !datasets.is_empty() {
-                    Card {
-                        class: "mt-5 has-data-table",
-                        CardHeader {
-                            title: "Datasets"
+                    div {
+                        class: "space-y-2",
+                        for dataset in &datasets {
+                            DatasetCard { team_id, rbac: rbac.clone(), dataset: dataset.clone() }
                         }
-                        CardBody {
-                            table {
-                                class: "table table-sm",
-                                thead {
-                                    th { "Name" }
-                                    th { "Visibility" }
-                                    th {
-                                        class: "max-sm:hidden",
-                                        "Document Count"
-                                    }
-                                    th {
-                                        class: "max-sm:hidden",
-                                        "Chunking Strategy"
-                                    }
-                                    th {
-                                        class: "text-right",
-                                        "Action"
-                                    }
-                                }
-                                tbody {
-
-                                    for dataset in &datasets {
-                                        tr {
-                                            td {
-                                                a {
-                                                    href: crate::routes::documents::Index{team_id, dataset_id: dataset.id}.to_string(),
-                                                    "{dataset.name}"
-                                                }
-                                            }
-                                            td {
-                                                crate::assistants::visibility::VisLabel {
-                                                    visibility: dataset.visibility
-                                                }
-                                            }
-                                            td {
-                                                class: "max-sm:hidden",
-                                                "{dataset.count}"
-                                            }
-                                            td {
-                                                class: "max-sm:hidden",
-                                                Badge {
-                                                    badge_color: BadgeColor::Accent,
-                                                    badge_style: BadgeStyle::Outline,
-                                                    badge_size: BadgeSize::Sm,
-                                                    "By Title"
-                                                }
-                                                }
-                                            td {
-                                                class: "text-right",
-                                                DropDown {
-                                                    direction: Direction::Left,
-                                                    button_text: "...",
-                                                    DropDownLink {
-                                                        href: crate::routes::documents::Index{team_id, dataset_id: dataset.id}.to_string(),
-                                                        target: "_top",
-                                                        "View"
-                                                    }
-
-                                                    if rbac.can_edit_dataset(dataset) {
-                                                        DropDownLink {
-                                                            popover_target: format!("edit-trigger-{}-{}",
-                                                                dataset.id, team_id),
-                                                            href: "#",
-                                                            target: "_top",
-                                                            "Edit"
-                                                        }
-                                                    }
-                                                    DropDownLink {
-                                                        popover_target: format!("delete-trigger-{}-{}",
-                                                            dataset.id, team_id),
-                                                        href: "#",
-                                                        target: "_top",
-                                                        "Delete"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                    }
 
                         for dataset in datasets {
                             ConfirmModal {
@@ -164,7 +85,6 @@ pub fn page(
                                 can_set_visibility_to_company
                             }
                         }
-                    }
                 }
 
                 super::upsert::Upsert {

--- a/crates/web-pages/documents/document_card.rs
+++ b/crates/web-pages/documents/document_card.rs
@@ -1,0 +1,97 @@
+#![allow(non_snake_case)]
+use crate::components::card_item::{CardItem, CountLabel};
+use daisy_rsx::*;
+use db::queries::documents::Document;
+use dioxus::prelude::*;
+
+#[component]
+pub fn DocumentCard(document: Document, team_id: i32, first_time: bool) -> Element {
+    let text = if let Some(failure_reason) = document.failure_reason.clone() {
+        failure_reason.replace(['{', '"', ':', '}'], " ")
+    } else {
+        "None".to_string()
+    };
+
+    let class = if document.waiting > 0 || document.batches == 0 {
+        "processing"
+    } else {
+        "processing-finished"
+    };
+
+    let id = format!("processing-label-{}", document.id);
+
+    let src = if first_time {
+        Some(
+            crate::routes::documents::Processing {
+                team_id,
+                document_id: document.id,
+            }
+            .to_string(),
+        )
+    } else {
+        None
+    };
+
+    let status = rsx! {
+        if document.waiting > 0 || document.batches == 0 {
+            turbo-frame {
+                id,
+                src,
+                Badge {
+                    class: class,
+                    badge_style: BadgeStyle::Outline,
+                    badge_size: BadgeSize::Sm,
+                    "Processing ({document.waiting} remaining)"
+                }
+            }
+        } else if document.failure_reason.is_some() {
+            turbo-frame {
+                id,
+                src,
+                ToolTip {
+                    text: "{text}",
+                    Badge {
+                        badge_color: BadgeColor::Error,
+                        badge_style: BadgeStyle::Outline,
+                        badge_size: BadgeSize::Sm,
+                        "Failed"
+                    }
+                }
+            }
+        } else if document.batches == 0 {
+            turbo-frame { id, src, Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Queued" } }
+        } else if document.fail_count > 0 {
+            turbo-frame { id, src, Badge { badge_color: BadgeColor::Error, badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Processed ({document.fail_count} failed)" } }
+        } else if document.failure_reason.is_some() {
+            turbo-frame { id, src, Badge { badge_color: BadgeColor::Error, badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Failed" } }
+        } else {
+            turbo-frame { id, src, Badge { badge_color: BadgeColor::Success, badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Processed" } }
+        }
+    };
+
+    rsx!(CardItem {
+        title: document.file_name.clone(),
+        description: Some(rsx!( span { "{document.content_size} bytes" } )),
+        footer: Some(status),
+        count_labels: vec![CountLabel {
+            count: document.batches as usize,
+            label: "Chunk".into()
+        }],
+        action: Some(rsx!(
+            DropDown {
+                direction: Direction::Left,
+                button_text: "...",
+                DropDownLink {
+                    popover_target: format!("delete-doc-trigger-{}-{}", document.id, team_id),
+                    href: "#",
+                    target: "_top",
+                    "Delete Document"
+                }
+            }
+        )),
+        class: None,
+        popover_target: None,
+        image_src: None,
+        avatar_name: None,
+    })
+}

--- a/crates/web-pages/documents/mod.rs
+++ b/crates/web-pages/documents/mod.rs
@@ -1,3 +1,4 @@
+pub mod document_card;
 pub mod page;
 pub mod status;
 pub mod upload;

--- a/crates/web-pages/documents/page.rs
+++ b/crates/web-pages/documents/page.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use super::document_card::DocumentCard;
 use crate::app_layout::{Layout, SideBar};
 use crate::components::confirm_modal::ConfirmModal;
 use crate::SectionIntroduction;
@@ -47,38 +48,10 @@ pub fn page(rbac: Rbac, team_id: i32, dataset: Dataset, documents: Vec<Document>
                 }
 
                 if !documents.is_empty() {
-                    Card {
-                        class: "mt-5 has-data-table",
-                        CardHeader {
-                            title: "Documents"
-                        }
-                        CardBody {
-                            table {
-                                id: "documents",
-                                class: "table table-sm",
-                                thead {
-                                    th { "Name" }
-                                    th {
-                                        class: "max-sm:hidden",
-                                        "No. Chunks"
-                                    }
-                                    th { "Content Size (Bytes)" }
-                                    th { "Status" }
-                                    th {
-                                        class: "text-right",
-                                        "Action"
-                                    }
-                                }
-                                tbody {
-                                    for doc in &documents {
-                                            Row {
-                                                document: doc.clone(),
-                                                team_id: team_id,
-                                                first_time: true
-                                            }
-                                    }
-                                }
-                            }
+                    div {
+                        class: "space-y-2",
+                        for doc in &documents {
+                            DocumentCard { document: doc.clone(), team_id: team_id, first_time: true }
                         }
                     }
 
@@ -107,130 +80,4 @@ pub fn page(rbac: Rbac, team_id: i32, dataset: Dataset, documents: Vec<Document>
     };
 
     crate::render(page)
-}
-
-#[component]
-pub fn Row(document: Document, team_id: i32, first_time: bool) -> Element {
-    let text = if let Some(failure_reason) = document.failure_reason.clone() {
-        failure_reason.replace(['{', '"', ':', '}'], " ")
-    } else {
-        "None".to_string()
-    };
-
-    let class = if document.waiting > 0 || document.batches == 0 {
-        "processing"
-    } else {
-        "processing-finished"
-    };
-
-    let id = format!("processing-label-{}", document.id);
-
-    let src = if first_time {
-        Some(
-            crate::routes::documents::Processing {
-                team_id,
-                document_id: document.id,
-            }
-            .to_string(),
-        )
-    } else {
-        None
-    };
-
-    rsx!(
-        tr {
-            td { "{document.file_name}" }
-            td {
-                class: "max-sm:hidden",
-                "{document.batches}"
-             }
-            td { "{document.content_size}" }
-            td {
-                if document.waiting > 0 || document.batches == 0 {
-                    turbo-frame {
-                        id,
-                        src,
-                        Badge {
-                            class: class,
-                            badge_style: BadgeStyle::Outline,
-                            badge_size: BadgeSize::Sm,
-                            "Processing ({document.waiting} remaining)"
-                        }
-                    }
-                } else if document.failure_reason.is_some() {
-                    turbo-frame {
-                        id,
-                        src,
-
-                        ToolTip {
-                            text: "{text}",
-                            Badge {
-                                badge_color: BadgeColor::Error,
-                                badge_style: BadgeStyle::Outline,
-                                badge_size: BadgeSize::Sm,
-                                "Failed"
-                            }
-                        }
-                    }
-                } else if document.batches == 0 {
-                    turbo-frame {
-                        id,
-                        src,
-
-                        Badge { badge_style: BadgeStyle::Outline, badge_size: BadgeSize::Sm, "Queued" }
-                    }
-                } else if document.fail_count > 0 {
-                    turbo-frame {
-                        id,
-                        src,
-
-                        Badge {
-                            badge_color: BadgeColor::Error,
-                            badge_style: BadgeStyle::Outline,
-                            badge_size: BadgeSize::Sm,
-                            "Processed ({document.fail_count} failed)"
-                        }
-                    }
-                } else if document.failure_reason.is_some() {
-                    turbo-frame {
-                        id,
-                        src,
-
-                        Badge {
-                            badge_color: BadgeColor::Error,
-                            badge_style: BadgeStyle::Outline,
-                            badge_size: BadgeSize::Sm,
-                            "Failed"
-                        }
-                    }
-                } else {
-                    turbo-frame {
-                        id,
-                        src,
-
-                        Badge {
-                            badge_color: BadgeColor::Success,
-                            badge_style: BadgeStyle::Outline,
-                            badge_size: BadgeSize::Sm,
-                            "Processed"
-                        }
-                    }
-                }
-            }
-            td {
-                class: "text-right",
-                DropDown {
-                    direction: Direction::Left,
-                    button_text: "...",
-                    DropDownLink {
-                        popover_target: format!("delete-doc-trigger-{}-{}",
-                            document.id, team_id),
-                        href: "#",
-                        target: "_top",
-                        "Delete Document"
-                    }
-                }
-            }
-        }
-    )
 }

--- a/crates/web-pages/documents/status.rs
+++ b/crates/web-pages/documents/status.rs
@@ -1,13 +1,10 @@
+use super::document_card::DocumentCard;
 use db::queries::documents::Document;
 use dioxus::prelude::*;
 
 pub fn status(document: Document, team_id: i32, first_time: bool) -> String {
     let row = rsx! {
-        super::page::Row {
-            team_id,
-            document,
-            first_time
-        }
+        DocumentCard { document, team_id, first_time }
     };
     dioxus_ssr::render_element(row)
 }


### PR DESCRIPTION
## Summary
- add reusable `DatasetCard` and `DocumentCard`
- render datasets and documents using `CardItem`
- wire up dataset/document card components in modules

## Testing
- `cargo check --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_687255ab311883209570a8a8858f31ba