### PR TITLE
Unify OAuth2 redirect URI generation

### DIFF
--- a/crates/web-pages/licence/page.rs
+++ b/crates/web-pages/licence/page.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 use crate::app_layout::{Layout, SideBar};
 use crate::components::card_item::CardItem;
-use crate::routes::integrations::OAuth2Callback;
+
 use assets::files::*;
 use daisy_rsx::*;
 use db::{authz::Rbac, customer_keys, Licence};
@@ -23,7 +23,7 @@ fn get_version() -> String {
         .to_string()
 }
 
-pub fn page(team_id: i32, rbac: Rbac) -> String {
+pub fn page(team_id: i32, rbac: Rbac, callback_url: String) -> String {
     let licence = Licence::global();
     let encryption = if customer_keys::get_customer_key().is_some() {
         "Enabled"
@@ -42,9 +42,6 @@ pub fn page(team_id: i32, rbac: Rbac) -> String {
         "Disabled"
     };
 
-    let base_url =
-        std::env::var("APP_BASE_URL").unwrap_or_else(|_| "http://localhost:7703".to_string());
-    let callback_url = format!("{}{}", base_url, OAuth2Callback {});
 
     let page = rsx! {
         Layout {

--- a/crates/web-server/config.rs
+++ b/crates/web-server/config.rs
@@ -1,5 +1,6 @@
 use lettre::message;
 use std::env;
+use web_pages::routes::integrations::OAuth2Callback;
 
 #[derive(Clone, Debug)]
 pub struct SmtpConfig {
@@ -107,5 +108,10 @@ impl Config {
             enable_barricade,
             base_url,
         }
+    }
+
+    /// Return the OAuth2 redirect URI used for integrations
+    pub fn oauth2_redirect_uri(&self) -> String {
+        format!("{}{}", self.base_url, OAuth2Callback {}.to_string())
     }
 }

--- a/crates/web-server/handlers/licence.rs
+++ b/crates/web-server/handlers/licence.rs
@@ -1,4 +1,4 @@
-use crate::{CustomError, Jwt};
+use crate::{config::Config, CustomError, Jwt};
 use axum::extract::Extension;
 use axum::response::Html;
 use axum::Router;
@@ -13,6 +13,7 @@ pub fn routes() -> Router {
 pub async fn loader(
     Index { team_id }: Index,
     current_user: Jwt,
+    Extension(config): Extension<Config>,
     Extension(pool): Extension<Pool>,
 ) -> Result<Html<String>, CustomError> {
     let mut client = pool.get().await?;
@@ -23,7 +24,8 @@ pub async fn loader(
         return Err(CustomError::Authorization);
     }
 
-    let html = licence::page::page(team_id, rbac);
+    let callback_url = config.oauth2_redirect_uri();
+    let html = licence::page::page(team_id, rbac, callback_url);
 
     Ok(Html(html))
 }

--- a/crates/web-server/handlers/oauth2.rs
+++ b/crates/web-server/handlers/oauth2.rs
@@ -72,8 +72,8 @@ pub async fn connect_loader(
         .map_err(|_| CustomError::FaultySetup("Invalid token endpoint URL".to_string()))?;
 
     // Set up the config for the OAuth2 process using dynamic configuration
-    let redirect_uri = format!("{}{}", config.base_url, OAuth2Callback {});
-    tracing::debug!("Redirect URI set to {}", redirect_uri);
+    let redirect_uri = config.oauth2_redirect_uri();
+    tracing::info!("Redirect URI set to {}", redirect_uri);
     let client = BasicClient::new(client_id)
         .set_client_secret(client_secret)
         .set_auth_uri(auth_url)
@@ -185,7 +185,7 @@ pub async fn oauth2_callback(
         .set_auth_uri(AuthUrl::new(oauth2_config.authorization_url).unwrap())
         .set_token_uri(TokenUrl::new(oauth2_config.token_url).unwrap())
         .set_redirect_uri(
-            RedirectUrl::new(format!("{}/app/oauth2/callback", config.base_url)).unwrap(),
+            RedirectUrl::new(config.oauth2_redirect_uri()).unwrap(),
         );
 
     // Validate CSRF state


### PR DESCRIPTION
## Summary
- add `oauth2_redirect_uri` helper to `Config`
- use new helper in OAuth2 handler and log redirect URI at info level
- pass unified redirect URI to licence page
- update licence page signature to accept callback URL

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6874bb1749408320beb29fdc02ffa90e