### PR TITLE
Force apply for operator patches

### DIFF
--- a/crates/k8s-operator/src/cli/install.rs
+++ b/crates/k8s-operator/src/cli/install.rs
@@ -162,7 +162,7 @@ async fn create_bionic_operator(client: &Client, namespace: &str) -> Result<()> 
     deployment_api
         .patch(
             "bionic-gpt-operator-deployment",
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(deployment),
         )
         .await?;
@@ -185,7 +185,7 @@ async fn create_roles(client: &Client, installer: &super::Installer) -> Result<(
     sa_api
         .patch(
             "bionic-gpt-operator-service-account",
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(service_account),
         )
         .await?;
@@ -206,7 +206,7 @@ async fn create_roles(client: &Client, installer: &super::Installer) -> Result<(
     role_api
         .patch(
             "bionic-gpt-operator-cluster-role",
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(role),
         )
         .await?;
@@ -233,7 +233,7 @@ async fn create_roles(client: &Client, installer: &super::Installer) -> Result<(
     role_binding_api
         .patch(
             "bionic-gpt-operator-cluster-role-binding",
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(role_binding),
         )
         .await?;
@@ -272,7 +272,7 @@ async fn create_bionic(client: &Client, installer: &super::Installer) -> Result<
     bionic_api
         .patch(
             "bionic-gpt",
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(bionic),
         )
         .await?;
@@ -285,7 +285,7 @@ async fn create_crd(client: &Client) -> Result<(), Error> {
     let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
     crds.patch(
         "bionics.bionic-gpt.com",
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &Patch::Apply(crd),
     )
     .await?;
@@ -317,7 +317,7 @@ async fn create_namespace(client: &Client, namespace: &str) -> Result<Namespace>
     let ns = namespaces
         .patch(
             namespace,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(new_namespace),
         )
         .await?;

--- a/crates/k8s-operator/src/services/deployment.rs
+++ b/crates/k8s-operator/src/services/deployment.rs
@@ -108,7 +108,7 @@ pub async fn deployment(
     let _deployment = deployment_api
         .patch(
             &service_deployment.name,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(deployment),
         )
         .await?;
@@ -165,7 +165,7 @@ pub async fn service(
     let service = service_api
         .patch(
             name,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(service),
         )
         .await?;

--- a/crates/k8s-operator/src/services/envoy.rs
+++ b/crates/k8s-operator/src/services/envoy.rs
@@ -27,7 +27,7 @@ pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result
     let api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     api.patch(
         "envoy",
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &Patch::Apply(config_map),
     )
     .await?;

--- a/crates/k8s-operator/src/services/http_mock.rs
+++ b/crates/k8s-operator/src/services/http_mock.rs
@@ -31,7 +31,7 @@ pub async fn deploy(client: Client, name: &str, port: u16, namespace: &str) -> R
     let api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     api.patch(
         name,
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &Patch::Apply(config_map),
     )
     .await?;

--- a/crates/k8s-operator/src/services/ingress.rs
+++ b/crates/k8s-operator/src/services/ingress.rs
@@ -130,7 +130,7 @@ pub async fn deploy(
     ingress_api
         .patch(
             INGRESS,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(ingress),
         )
         .await?;

--- a/crates/k8s-operator/src/services/keycloak.rs
+++ b/crates/k8s-operator/src/services/keycloak.rs
@@ -30,7 +30,7 @@ pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result
     let api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     api.patch(
         KEYCLOAK_NAME,
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &Patch::Apply(config_map),
     )
     .await?;

--- a/crates/k8s-operator/src/services/network_policy.rs
+++ b/crates/k8s-operator/src/services/network_policy.rs
@@ -71,7 +71,7 @@ pub async fn default_deny(client: Client, name: &str, namespace: &str) -> Result
     policies
         .patch(
             &policy_name,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(policy),
         )
         .await?;

--- a/crates/k8s-operator/src/services/observability.rs
+++ b/crates/k8s-operator/src/services/observability.rs
@@ -32,7 +32,7 @@ pub async fn deploy(
     let api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     api.patch(
         CONFIG_NAME,
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &Patch::Apply(config_map),
     )
     .await?;

--- a/crates/k8s-operator/src/services/pgadmin.rs
+++ b/crates/k8s-operator/src/services/pgadmin.rs
@@ -53,7 +53,7 @@ pub async fn deploy(
     if api.get(PGADMIN).await.is_err() {
         api.patch(
             PGADMIN,
-            &PatchParams::apply(crate::MANAGER),
+            &PatchParams::apply(crate::MANAGER).force(),
             &Patch::Apply(config_map),
         )
         .await?;

--- a/crates/k8s-operator/src/services/tgi.rs
+++ b/crates/k8s-operator/src/services/tgi.rs
@@ -66,7 +66,7 @@ pub async fn deploy(client: Client, namespace: &str) -> Result<(), Error> {
     let api: Api<Pod> = Api::namespaced(client.clone(), namespace);
     api.patch(
         MODEL_NAME,
-        &PatchParams::apply(crate::MANAGER),
+        &PatchParams::apply(crate::MANAGER).force(),
         &kube::api::Patch::Apply(pod),
     )
     .await?;


### PR DESCRIPTION
## Summary
- apply Kubernetes patches with `force()` so operator reconciles even if fields were modified by another manager

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6874d00b6b0883208e2ea6e5b59f6f6e