### PR TITLE
Remove default integration logo

### DIFF
--- a/crates/integrations/bionic_openapi.rs
+++ b/crates/integrations/bionic_openapi.rs
@@ -27,9 +27,6 @@ pub struct OAuth2Config {
     pub scopes: Vec<String>,
 }
 
-// Default placeholder SVG for integrations without logos
-const DEFAULT_INTEGRATION_LOGO: &str = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgiIGhlaWdodD0iNDgiIHZpZXdCb3g9IjAgMCA0OCA0OCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4IiByeD0iOCIgZmlsbD0iIzZCNzI4MCIvPgo8cGF0aCBkPSJNMTYgMTZIMzJWMjBIMTZWMTZaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNMTYgMjRIMzJWMjhIMTZWMjRaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNMTYgMzJIMjhWMzZIMTZWMzJaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K";
-
 /// A wrapper around an OpenAPI v3 specification that provides methods
 /// for extracting tool definitions and handling OpenAPI operations
 #[derive(Clone, PartialEq, Debug)]
@@ -66,7 +63,7 @@ impl BionicOpenAPI {
     }
 
     /// Safely extracts the logo URL from integration extensions
-    pub fn get_logo_url(&self) -> String {
+    pub fn get_logo_url(&self) -> Option<String> {
         self.spec
             .info
             .extensions
@@ -76,7 +73,6 @@ impl BionicOpenAPI {
             .and_then(|url| url.as_str())
             .filter(|url| !url.is_empty())
             .map(|url| url.to_string())
-            .unwrap_or_else(|| DEFAULT_INTEGRATION_LOGO.to_string())
     }
 
     /// Create tool definitions from the OpenAPI specification

--- a/crates/web-pages/integrations/actions_section.rs
+++ b/crates/web-pages/integrations/actions_section.rs
@@ -1,10 +1,14 @@
 #![allow(non_snake_case)]
 use super::parameter_renderer::render_parameter;
+use daisy_rsx::*;
 use dioxus::prelude::*;
 use openai_api::BionicToolDefinition;
 
 #[component]
-pub fn ActionsSection(logo_url: String, tool_definitions: Vec<BionicToolDefinition>) -> Element {
+pub fn ActionsSection(
+    logo_url: Option<String>,
+    tool_definitions: Vec<BionicToolDefinition>,
+) -> Element {
     rsx! {
         div {
             h2 {
@@ -21,11 +25,18 @@ pub fn ActionsSection(logo_url: String, tool_definitions: Vec<BionicToolDefiniti
                                 class: "flex",
                                 div {
                                     class: "flex flex-col justify-center",
-                                    img {
-                                        class: "border border-neutral-content  rounded p-1",
-                                        src: "{logo_url}",
-                                        width: "32",
-                                        height: "32"
+                                    if let Some(url) = logo_url.clone() {
+                                        img {
+                                            class: "border border-neutral-content  rounded p-1",
+                                            src: "{url}",
+                                            width: "32",
+                                            height: "32"
+                                        }
+                                    } else {
+                                        Avatar {
+                                            avatar_size: AvatarSize::Medium,
+                                            name: "{tool.function.name}"
+                                        }
                                     }
                                 }
                                 div {

--- a/crates/web-pages/integrations/integration_card.rs
+++ b/crates/web-pages/integrations/integration_card.rs
@@ -27,11 +27,13 @@ pub fn IntegrationCard(integration: IntegrationSummary, team_id: i32) -> Element
 
     let description = integration.openapi.get_description().unwrap_or_default();
 
+    let logo_url = integration.openapi.get_logo_url();
     rsx! {
         CardItem {
             class: Some("cursor-pointer hover:bg-base-200 w-full".into()),
             clickable_link: crate::routes::integrations::View { team_id, id: integration.id }.to_string(),
-            image_src: Some(integration.openapi.get_logo_url()),
+            image_src: logo_url.clone(),
+            avatar_name: if logo_url.is_none() { Some(integration.openapi.get_title()) } else { None },
             title: integration.openapi.get_title().to_string(),
             description: if description.is_empty() { None } else { Some(rsx!(span { "{description}" })) },
             count_labels: if has_oauth2 || has_api_key {

--- a/crates/web-pages/integrations/integration_header.rs
+++ b/crates/web-pages/integrations/integration_header.rs
@@ -11,7 +11,7 @@ pub fn IntegrationHeader(
     team_id: i32,
     rbac: Rbac,
     integration: Integration,
-    logo_url: String,
+    logo_url: Option<String>,
     description: Option<String>,
 ) -> Element {
     let popover_target = format!("delete-integration-{}", integration.id);
@@ -21,11 +21,18 @@ pub fn IntegrationHeader(
             class: "flex justify-between",
             div {
                 class: "flex items-center",
-                img {
-                    class: "w-12 h-12 object-contain border border-neutral-content rounded p-2",
-                    src: "{logo_url}",
-                    width: "48",
-                    height: "48"
+                if let Some(url) = logo_url.clone() {
+                    img {
+                        class: "w-12 h-12 object-contain border border-neutral-content rounded p-2",
+                        src: "{url}",
+                        width: "48",
+                        height: "48"
+                    }
+                } else {
+                    Avatar {
+                        avatar_size: AvatarSize::Medium,
+                        name: "{integration.name.clone()}"
+                    }
                 }
                 div {
                     class: "ml-4",


### PR DESCRIPTION
## Summary
- return `Option<String>` from `get_logo_url`
- use avatar as fallback in `IntegrationCard`, `IntegrationHeader` and `ActionsSection`

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_68777a432aa88320ab751ad230a80dd7