### PR TITLE
Add batch processing for RAG engine

### DIFF
--- a/crates/db/queries/chunks.sql
+++ b/crates/db/queries/chunks.sql
@@ -37,7 +37,10 @@ SELECT
 FROM
     chunks
 WHERE
-    processed IS NOT TRUE;
+    processed IS NOT TRUE
+ORDER BY
+    id
+LIMIT :limit;
 
 --! delete
 DELETE FROM chunks WHERE id = :embedding_id;

--- a/crates/db/queries/documents.sql
+++ b/crates/db/queries/documents.sql
@@ -9,7 +9,10 @@ FROM
 WHERE
     failure_reason IS NULL
     AND
-    id NOT IN (SELECT document_id FROM chunks WHERE document_id = d.id);
+    id NOT IN (SELECT document_id FROM chunks WHERE document_id = d.id)
+ORDER BY
+    id
+LIMIT :limit;
 
 --! fail_document
 UPDATE documents SET failure_reason = :failure_reason WHERE id = :id;

--- a/crates/rag-engine/src/config.rs
+++ b/crates/rag-engine/src/config.rs
@@ -4,6 +4,7 @@ use std::env;
 pub struct Config {
     pub app_database_url: String,
     pub unstructured_endpoint: String,
+    pub batch_size: i64,
 }
 
 impl Default for Config {
@@ -22,9 +23,15 @@ impl Config {
             "http://chunking-engine:8000".to_string()
         };
 
+        let batch_size = std::env::var("RAG_BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10);
+
         Config {
             app_database_url,
             unstructured_endpoint,
+            batch_size,
         }
     }
 }


### PR DESCRIPTION
## Summary
- limit unprocessed document and chunk queries
- make rag-engine batch size configurable
- fetch records in batches in rag-engine

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_687934db21fc83208f4568578f614a93