### PR TITLE
Add embeddings-engine to network policy allowlist

### DIFF
--- a/crates/k8s-operator/src/services/network_policy.rs
+++ b/crates/k8s-operator/src/services/network_policy.rs
@@ -1,4 +1,6 @@
-use super::{bionic::BIONIC_NAME, keycloak::KEYCLOAK_NAME};
+use super::{
+    bionic::BIONIC_NAME, embeddings_engine::NAME as EMBEDDINGS_NAME, keycloak::KEYCLOAK_NAME,
+};
 use crate::error::Error;
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{Patch, PatchParams};
@@ -29,7 +31,7 @@ pub async fn default_deny(client: Client, name: &str, namespace: &str) -> Result
     }]);
 
     // Egress: allow DNS + namespace-local traffic
-    let egress = if name == BIONIC_NAME || name == KEYCLOAK_NAME {
+    let egress = if name == BIONIC_NAME || name == KEYCLOAK_NAME || name == EMBEDDINGS_NAME {
         json!([
             { "to": [{ "ipBlock": { "cidr": "0.0.0.0/0" } }] }
         ])


### PR DESCRIPTION
## Summary
- allow unrestricted egress for the embeddings API

## Testing
- `cargo build -p k8s-operator`

------
https://chatgpt.com/codex/tasks/task_e_6880890c3bbc8320b0ba49abcf027de8