### PR TITLE
Fix invite role to TeamManager

### DIFF
--- a/crates/web-server/handlers/team/create_invite.rs
+++ b/crates/web-server/handlers/team/create_invite.rs
@@ -102,7 +102,7 @@ pub async fn create(
 
     let roles = if new_invite.admin.is_some() {
         vec![
-            types::public::Role::SystemAdministrator,
+            types::public::Role::TeamManager,
             types::public::Role::Collaborator,
         ]
     } else {


### PR DESCRIPTION
## Summary
- fix role assignment for team invites

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6880a7f7c9248320a400b9945ba262fc