### PR TITLE
Hide public visibility option when SaaS enabled

### DIFF
--- a/crates/web-pages/my_assistants/upsert.rs
+++ b/crates/web-pages/my_assistants/upsert.rs
@@ -34,7 +34,7 @@ pub struct PromptForm {
     pub models: Vec<Prompt>,
 }
 
-pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
+pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm, show_company_visibility: bool) -> String {
     let example1 = prompt.example1.clone().unwrap_or_default();
     let example2 = prompt.example2.clone().unwrap_or_default();
     let example3 = prompt.example3.clone().unwrap_or_default();
@@ -164,7 +164,7 @@ pub fn page(team_id: i32, rbac: Rbac, prompt: PromptForm) -> String {
                                                     selected_value: "{prompt.visibility}",
                                                     {crate::visibility_to_string(Visibility::Team)}
                                                 },
-                                                if rbac.can_make_assistant_public() {
+                                                if show_company_visibility {
                                                     SelectOption {
                                                         value: "{crate::visibility_to_string(Visibility::Company)}",
                                                         selected_value: "{prompt.visibility}",

--- a/crates/web-server/handlers/assistants/loaders.rs
+++ b/crates/web-server/handlers/assistants/loaders.rs
@@ -1,4 +1,4 @@
-use crate::{CustomError, Jwt};
+use crate::{config::Config, CustomError, Jwt};
 use axum::extract::Extension;
 use axum::response::Html;
 use db::authz;
@@ -39,6 +39,7 @@ pub async fn new_assistant_loader(
     New { team_id }: New,
     current_user: Jwt,
     Extension(pool): Extension<Pool>,
+    Extension(config): Extension<Config>,
 ) -> Result<Html<String>, CustomError> {
     let mut client = pool.get().await?;
     let transaction = client.transaction().await?;
@@ -88,7 +89,9 @@ pub async fn new_assistant_loader(
         error: None,
     };
 
-    let html = web_pages::my_assistants::upsert::page(team_id, rbac, form);
+    let show_company_visibility = rbac.can_make_assistant_public() && !config.saas;
+
+    let html = web_pages::my_assistants::upsert::page(team_id, rbac, form, show_company_visibility);
 
     Ok(Html(html))
 }
@@ -97,6 +100,7 @@ pub async fn edit_assistant_loader(
     Edit { team_id, prompt_id }: Edit,
     current_user: Jwt,
     Extension(pool): Extension<Pool>,
+    Extension(config): Extension<Config>,
 ) -> Result<Html<String>, CustomError> {
     let mut client = pool.get().await?;
     let transaction = client.transaction().await?;
@@ -173,7 +177,9 @@ pub async fn edit_assistant_loader(
         error: None,
     };
 
-    let html = web_pages::my_assistants::upsert::page(team_id, rbac, form);
+    let show_company_visibility = rbac.can_make_assistant_public() && !config.saas;
+
+    let html = web_pages::my_assistants::upsert::page(team_id, rbac, form, show_company_visibility);
 
     Ok(Html(html))
 }


### PR DESCRIPTION
## Summary
- hide the `Everyone` visibility choice when SaaS mode is active
- pass SaaS config flag to assistant edit loaders

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6880ab040f1883209c93ab0798fdc401