### PR TITLE
Add categories management UI

### DIFF
--- a/crates/db/queries/categories.sql
+++ b/crates/db/queries/categories.sql
@@ -1,2 +1,16 @@
 --! categories : Category()
 SELECT id, name, description FROM categories;
+
+--! insert
+INSERT INTO categories (name, description)
+VALUES (:name, :description)
+RETURNING id;
+
+--! update
+UPDATE categories
+SET name = :name,
+    description = :description
+WHERE id = :id;
+
+--! delete
+DELETE FROM categories WHERE id = :id;

--- a/crates/web-pages/app_layout.rs
+++ b/crates/web-pages/app_layout.rs
@@ -21,6 +21,7 @@ pub enum SideBar {
     Integrations,
     Licence,
     Models,
+    Categories,
     OauthClients,
     Prompts,
     Profile,
@@ -198,6 +199,13 @@ pub fn Layout(props: LayoutProps) -> Element {
                                     href: super::routes::oauth_clients::Index { team_id: props.team_id },
                                     icon: nav_api_keys_svg.name,
                                     title: "OAuth Clients"
+                                }
+                                NavItem {
+                                    id: SideBar::Categories.to_string(),
+                                    selected_item_id: props.selected_item.to_string(),
+                                    href: super::routes::categories::Index { team_id: props.team_id },
+                                    icon: nav_audit_svg.name,
+                                    title: "Categories"
                                 }
                                 NavItem {
                                     id: SideBar::Licence.to_string(),

--- a/crates/web-pages/categories/mod.rs
+++ b/crates/web-pages/categories/mod.rs
@@ -1,0 +1,2 @@
+pub mod page;
+pub mod upsert;

--- a/crates/web-pages/categories/page.rs
+++ b/crates/web-pages/categories/page.rs
@@ -1,0 +1,116 @@
+#![allow(non_snake_case)]
+use crate::app_layout::{Layout, SideBar};
+use crate::components::confirm_modal::ConfirmModal;
+use crate::SectionIntroduction;
+use assets::files::*;
+use daisy_rsx::*;
+use db::authz::Rbac;
+use db::Category;
+use dioxus::prelude::*;
+
+pub fn page(team_id: i32, rbac: Rbac, categories: Vec<Category>) -> String {
+    let page = rsx! {
+        Layout {
+            section_class: "p-4",
+            selected_item: SideBar::Categories,
+            team_id: team_id,
+            rbac: rbac.clone(),
+            title: "Categories",
+            header: rsx!(
+                Breadcrumb {
+                    items: vec![BreadcrumbItem { text: "Categories".into(), href: None }]
+                }
+                if rbac.is_sys_admin {
+                    Button {
+                        prefix_image_src: "{button_plus_svg.name}",
+                        popover_target: "new-category-form",
+                        button_scheme: ButtonScheme::Primary,
+                        "Add Category"
+                    }
+                }
+            ),
+            div {
+                class: "p-4 max-w-3xl w-full mx-auto",
+                SectionIntroduction {
+                    header: "Categories".to_string(),
+                    subtitle: "Organize your assistants with custom categories.".to_string(),
+                    is_empty: categories.is_empty(),
+                    empty_text: "No categories defined yet.".to_string(),
+                }
+                if !categories.is_empty() {
+                    Card {
+                        class: "mt-5 has-data-table",
+                        CardHeader { title: "Categories" }
+                        CardBody {
+                            table {
+                                class: "table table-sm",
+                                thead {
+                                    th { "Name" }
+                                    th { "Description" }
+                                    th { class: "text-right", "Action" }
+                                }
+                                tbody {
+                                    for category in &categories {
+                                        tr {
+                                            td { "{category.name}" }
+                                            td { "{category.description}" }
+                                            td {
+                                                class: "text-right",
+                                                DropDown {
+                                                    direction: Direction::Left,
+                                                    button_text: "...",
+                                                    DropDownLink {
+                                                        popover_target: format!("edit-trigger-{}-{}", category.id, team_id),
+                                                        href: "#",
+                                                        target: "_top",
+                                                        "Edit"
+                                                    }
+                                                    DropDownLink {
+                                                        popover_target: format!("delete-trigger-{}-{}", category.id, team_id),
+                                                        href: "#",
+                                                        target: "_top",
+                                                        "Delete"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        for category in categories {
+                            ConfirmModal {
+                                action: crate::routes::categories::Delete { team_id, id: category.id }.to_string(),
+                                trigger_id: format!("delete-trigger-{}-{}", category.id, team_id),
+                                submit_label: "Delete".to_string(),
+                                heading: "Delete this Category?".to_string(),
+                                warning: "Are you sure you want to delete this Category?".to_string(),
+                                hidden_fields: vec![
+                                    ("team_id".into(), team_id.to_string()),
+                                    ("id".into(), category.id.to_string()),
+                                ],
+                            }
+                            super::upsert::Upsert {
+                                id: Some(category.id),
+                                trigger_id: format!("edit-trigger-{}-{}", category.id, team_id),
+                                name: category.name,
+                                description: category.description,
+                                team_id
+                            }
+                        }
+                    }
+                }
+                if rbac.is_sys_admin {
+                    super::upsert::Upsert {
+                        id: None,
+                        trigger_id: "new-category-form",
+                        name: "".to_string(),
+                        description: "".to_string(),
+                        team_id
+                    }
+                }
+            }
+        }
+    };
+    crate::render(page)
+}

--- a/crates/web-pages/categories/upsert.rs
+++ b/crates/web-pages/categories/upsert.rs
@@ -1,0 +1,43 @@
+#![allow(non_snake_case)]
+use daisy_rsx::*;
+use dioxus::prelude::*;
+
+#[component]
+pub fn Upsert(
+    id: Option<i32>,
+    trigger_id: String,
+    name: String,
+    description: String,
+    team_id: i32,
+) -> Element {
+    rsx!(
+        Modal {
+            submit_action: crate::routes::categories::Upsert { team_id }.to_string(),
+            trigger_id,
+            ModalBody {
+                class: "flex flex-col gap-4",
+                h3 { class: "font-bold text-lg mb-4", "Category" }
+                if let Some(id) = id {
+                    input { "type": "hidden", name: "id", value: "{id}" }
+                }
+                Fieldset {
+                    legend: "Name",
+                    Input {
+                        input_type: InputType::Text,
+                        name: "name",
+                        value: name,
+                        required: true,
+                    }
+                }
+                Fieldset {
+                    legend: "Description",
+                    TextArea { name: "description", rows: "4", "{description}" }
+                }
+                ModalAction {
+                    Button { class: "cancel-modal", button_scheme: ButtonScheme::Warning, "Cancel" }
+                    Button { button_type: ButtonType::Submit, button_scheme: ButtonScheme::Primary, "Save" }
+                }
+            }
+        }
+    )
+}

--- a/crates/web-pages/lib.rs
+++ b/crates/web-pages/lib.rs
@@ -7,6 +7,7 @@ pub mod assistants;
 pub mod audit_trail;
 pub mod automations;
 pub mod base_layout;
+pub mod categories;
 pub mod charts;
 pub mod components;
 pub mod console;

--- a/crates/web-pages/routes.rs
+++ b/crates/web-pages/routes.rs
@@ -502,6 +502,30 @@ pub mod datasets {
     }
 }
 
+pub mod categories {
+    use axum_extra::routing::TypedPath;
+    use serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/app/team/{team_id}/categories")]
+    pub struct Index {
+        pub team_id: i32,
+    }
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/app/team/{team_id}/categories/upsert")]
+    pub struct Upsert {
+        pub team_id: i32,
+    }
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/app/team/{team_id}/categories/delete/{id}")]
+    pub struct Delete {
+        pub team_id: i32,
+        pub id: i32,
+    }
+}
+
 pub mod documents {
     use axum_extra::routing::TypedPath;
     use serde::Deserialize;

--- a/crates/web-server/handlers/categories/actions.rs
+++ b/crates/web-server/handlers/categories/actions.rs
@@ -1,0 +1,88 @@
+use crate::{CustomError, Jwt};
+use axum::{
+    extract::{Extension, Form},
+    response::IntoResponse,
+};
+use db::authz;
+use db::{queries, Pool};
+use serde::Deserialize;
+use validator::Validate;
+use web_pages::routes::categories::{Delete, Upsert};
+
+#[derive(Deserialize, Validate, Default, Debug)]
+pub struct CategoryForm {
+    pub id: Option<i32>,
+    #[validate(length(min = 1, message = "The name is mandatory"))]
+    pub name: String,
+    pub description: String,
+}
+
+pub async fn action_upsert(
+    Upsert { team_id }: Upsert,
+    current_user: Jwt,
+    Extension(pool): Extension<Pool>,
+    Form(form): Form<CategoryForm>,
+) -> Result<impl IntoResponse, CustomError> {
+    let mut client = pool.get().await?;
+    let transaction = client.transaction().await?;
+    let rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
+
+    if !rbac.is_sys_admin {
+        return Err(CustomError::Authorization);
+    }
+
+    match (form.validate(), form.id) {
+        (Ok(_), Some(id)) => {
+            queries::categories::update()
+                .bind(&transaction, &form.name, &form.description, &id)
+                .await?;
+            transaction.commit().await?;
+            Ok(crate::layout::redirect_and_snackbar(
+                &web_pages::routes::categories::Index { team_id }.to_string(),
+                "Category Updated",
+            )
+            .into_response())
+        }
+        (Ok(_), None) => {
+            queries::categories::insert()
+                .bind(&transaction, &form.name, &form.description)
+                .one()
+                .await?;
+            transaction.commit().await?;
+            Ok(crate::layout::redirect_and_snackbar(
+                &web_pages::routes::categories::Index { team_id }.to_string(),
+                "Category Created",
+            )
+            .into_response())
+        }
+        (Err(_), _) => Ok(crate::layout::redirect_and_snackbar(
+            &web_pages::routes::categories::Index { team_id }.to_string(),
+            "Category Validation Error",
+        )
+        .into_response()),
+    }
+}
+
+pub async fn action_delete(
+    Delete { team_id, id }: Delete,
+    current_user: Jwt,
+    Extension(pool): Extension<Pool>,
+) -> Result<impl IntoResponse, CustomError> {
+    let mut client = pool.get().await?;
+    let transaction = client.transaction().await?;
+    let rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
+
+    if !rbac.is_sys_admin {
+        return Err(CustomError::Authorization);
+    }
+
+    queries::categories::delete()
+        .bind(&transaction, &id)
+        .await?;
+    transaction.commit().await?;
+
+    crate::layout::redirect_and_snackbar(
+        &web_pages::routes::categories::Index { team_id }.to_string(),
+        "Category Deleted",
+    )
+}

--- a/crates/web-server/handlers/categories/loader.rs
+++ b/crates/web-server/handlers/categories/loader.rs
@@ -1,0 +1,29 @@
+use crate::{CustomError, Jwt};
+use axum::{extract::Extension, response::Html};
+use db::authz;
+use db::{queries, Pool};
+use web_pages::routes::categories::Index;
+
+pub async fn loader(
+    Index { team_id }: Index,
+    current_user: Jwt,
+    Extension(pool): Extension<Pool>,
+) -> Result<Html<String>, CustomError> {
+    let mut client = pool.get().await?;
+    let transaction = client.transaction().await?;
+
+    let rbac = authz::get_permissions(&transaction, &current_user.into(), team_id).await?;
+
+    if !rbac.is_sys_admin {
+        return Err(CustomError::Authorization);
+    }
+
+    let categories = queries::categories::categories()
+        .bind(&transaction)
+        .all()
+        .await?;
+
+    let html = web_pages::categories::page::page(team_id, rbac, categories);
+
+    Ok(Html(html))
+}

--- a/crates/web-server/handlers/categories/mod.rs
+++ b/crates/web-server/handlers/categories/mod.rs
@@ -1,0 +1,15 @@
+mod actions;
+mod loader;
+
+pub use actions::*;
+pub use loader::*;
+
+use axum::Router;
+use axum_extra::routing::RouterExt;
+
+pub fn routes() -> Router {
+    Router::new()
+        .typed_get(loader::loader)
+        .typed_post(actions::action_upsert)
+        .typed_post(actions::action_delete)
+}

--- a/crates/web-server/handlers/mod.rs
+++ b/crates/web-server/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod api_pipeline;
 pub mod assistants;
 pub mod audit_trail;
 pub mod automations;
+pub mod categories;
 pub mod console;
 pub mod datasets;
 pub mod documents;

--- a/crates/web-server/main.rs
+++ b/crates/web-server/main.rs
@@ -94,6 +94,7 @@ async fn main() {
         .merge(handlers::oauth_clients::routes())
         .merge(llm_proxy::routes())
         .merge(handlers::models::routes())
+        .merge(handlers::categories::routes())
         .merge(handlers::pipelines::routes())
         .merge(handlers::profile::routes())
         .merge(handlers::assistants::routes())


### PR DESCRIPTION
## Summary
- add insert/update/delete queries for categories
- implement server handlers for categories
- create categories page with add/edit/delete modal
- expose categories routes and sidebar navigation

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6880bc3582ac8320a9bb295f82a5c00f