### PR TITLE
Add upload limit config map and attachment controls

### DIFF
--- a/crates/web-assets/typescript/console/file-upload.ts
+++ b/crates/web-assets/typescript/console/file-upload.ts
@@ -10,6 +10,10 @@ export function fileUpload() {
   const attachButton = document.getElementById('attach-button');
   if (!attachButton) return;
 
+  // Read the maximum number of files from a data attribute
+  const maxFilesAttr = attachButton.getAttribute('data-max-files');
+  const MAX_FILES = maxFilesAttr ? parseInt(maxFilesAttr, 10) : 5;
+
   // Create a hidden file input element
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
@@ -43,10 +47,10 @@ export function fileUpload() {
   // File selection handler
   fileInput.addEventListener('change', () => {
     if (fileInput.files && fileInput.files.length > 0) {
-      const availableSlots = Math.max(0, 5 - selectedFiles.size);
+      const availableSlots = Math.max(0, MAX_FILES - selectedFiles.size);
       const files = Array.from(fileInput.files);
       if (files.length > availableSlots) {
-        alert('You can only upload up to 5 files.');
+        alert(`You can only upload up to ${MAX_FILES} files.`);
       }
       files.slice(0, availableSlots).forEach(file => {
         const key = `${file.name}-${file.lastModified}`;

--- a/crates/web-pages/console/prompt_form.rs
+++ b/crates/web-pages/console/prompt_form.rs
@@ -137,13 +137,20 @@ fn SpeechToTextButton(lock_console: bool) -> Element {
 
 #[component]
 fn AttachButton(lock_console: bool, id: &'static str) -> Element {
+    let max_files: usize = std::env::var("MAX_ATTACHMENTS")
+        .unwrap_or_else(|_| "5".to_string())
+        .parse()
+        .unwrap_or(5);
     rsx! {
-        Button {
+        button {
             id: id,
-            button_style: ButtonStyle::Outline,
-            button_shape: ButtonShape::Circle,
+            class: "btn btn-outline btn-circle",
             disabled: lock_console,
-            prefix_image_src: attach_svg.name
+            "data-max-files": "{max_files}",
+            img {
+                class: "svg-icon",
+                src: attach_svg.name,
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- use config map for `MAX_UPLOAD_SIZE_MB` and new `MAX_ATTACHMENTS`
- reference these values in the console upload widget
- expose max attachment limit via page data attribute
- clean up config map on uninstall

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6880bfce44048320a3d88b38448a3099