### PR TITLE
Fix copy message markup

### DIFF
--- a/crates/web-assets/typescript/console/copy.ts
+++ b/crates/web-assets/typescript/console/copy.ts
@@ -9,10 +9,10 @@ export const copy = () => {
             const previousElement = parent?.parentElement?.previousElementSibling;
 
             const clickedImage = copyIcon.getAttribute("clicked-img")
-    
+
             if (previousElement && clickedImage && copyIcon instanceof HTMLImageElement) {
-                const previousElementContent = previousElement.innerHTML;
-                copyToClipboard(previousElementContent);
+                const previousElementContent = previousElement.textContent ?? "";
+                copyToClipboard(previousElementContent.trim());
                 const originalImage = copyIcon.src
                 copyIcon.src = clickedImage
 


### PR DESCRIPTION
## Summary
- fix copy icon to copy clean text

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6881cef674fc83208ecbee459b3be29a