### PR TITLE
Fix rag engine network policy

### DIFF
--- a/crates/k8s-operator/src/services/network_policy.rs
+++ b/crates/k8s-operator/src/services/network_policy.rs
@@ -1,6 +1,4 @@
-use super::{
-    bionic::BIONIC_NAME, embeddings_engine::NAME as EMBEDDINGS_NAME, keycloak::KEYCLOAK_NAME,
-};
+use super::{bionic::BIONIC_NAME, keycloak::KEYCLOAK_NAME, rag_engine::NAME as RAG_ENGINE_NAME};
 use crate::error::Error;
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{Patch, PatchParams};
@@ -31,7 +29,7 @@ pub async fn default_deny(client: Client, name: &str, namespace: &str) -> Result
     }]);
 
     // Egress: allow DNS + namespace-local traffic
-    let egress = if name == BIONIC_NAME || name == KEYCLOAK_NAME || name == EMBEDDINGS_NAME {
+    let egress = if name == BIONIC_NAME || name == KEYCLOAK_NAME || name == RAG_ENGINE_NAME {
         json!([
             { "to": [{ "ipBlock": { "cidr": "0.0.0.0/0" } }] }
         ])

--- a/crates/k8s-operator/src/services/rag_engine.rs
+++ b/crates/k8s-operator/src/services/rag_engine.rs
@@ -7,7 +7,7 @@ use kube::api::DeleteParams;
 use kube::{Api, Client};
 use serde_json::json;
 
-const RAG_ENGINE: &str = "bionic-rag-engine";
+pub const NAME: &str = "bionic-rag-engine";
 
 // The RAG Engine
 pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result<(), Error> {
@@ -28,7 +28,7 @@ pub async fn deploy(client: Client, spec: BionicSpec, namespace: &str) -> Result
     deployment::deployment(
         client.clone(),
         deployment::ServiceDeployment {
-            name: RAG_ENGINE.to_string(),
+            name: NAME.to_string(),
             image_name,
             replicas: spec.replicas,
             port: 3000,
@@ -84,14 +84,14 @@ pub async fn delete_old_pipeline_job(client: Client, namespace: &str) -> Result<
 pub async fn delete(client: Client, namespace: &str) -> Result<(), Error> {
     // Remove deployments
     let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
-    if api.get(RAG_ENGINE).await.is_ok() {
-        api.delete(RAG_ENGINE, &DeleteParams::default()).await?;
+    if api.get(NAME).await.is_ok() {
+        api.delete(NAME, &DeleteParams::default()).await?;
     }
 
     // Remove services
     let api: Api<Service> = Api::namespaced(client.clone(), namespace);
-    if api.get(RAG_ENGINE).await.is_ok() {
-        api.delete(RAG_ENGINE, &DeleteParams::default()).await?;
+    if api.get(NAME).await.is_ok() {
+        api.delete(NAME, &DeleteParams::default()).await?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- expose rag engine name constant
- use rag engine instead of embeddings engine in network policy

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_6881ee16ac0c8320a8afd4290a4b1611