### PR TITLE
Fix disabled upload button without selected file

### DIFF
--- a/crates/web-assets/typescript/disable-submit-button.ts
+++ b/crates/web-assets/typescript/disable-submit-button.ts
@@ -1,18 +1,25 @@
 export const disableSubmitButton = () => {
-    // Persist a form to local storage.
+    // Disable submit buttons only when the form is valid.
     document.querySelectorAll('button[type="submit"]').forEach((button) => {
-        button.addEventListener("click", function() {
-            if(button instanceof HTMLButtonElement) {
-                setTimeout(() => {
-    
-                    const text = button.getAttribute("data-disabled-text")
-                    if(text) {
-                        button.innerHTML = text
-                        button.disabled = true
-                    }
+        button.addEventListener("click", function () {
+            if (button instanceof HTMLButtonElement) {
+                const form = button.form;
 
-                }, 1)
+                // If the form is invalid (e.g. no file selected), let the browser
+                // handle validation and keep the button active.
+                if (form && !form.checkValidity()) {
+                    return;
+                }
+
+                // Otherwise disable the button and show the loading text.
+                setTimeout(() => {
+                    const text = button.getAttribute("data-disabled-text");
+                    if (text) {
+                        button.innerHTML = text;
+                        button.disabled = true;
+                    }
+                }, 1);
             }
-        }, {once : true});
-    })
-}
+        });
+    });
+};


### PR DESCRIPTION
## Summary
- avoid disabling submit buttons when form validation fails

## Testing
- `cargo test --workspace --exclude integration-testing --exclude rag-engine`

------
https://chatgpt.com/codex/tasks/task_e_68860c8e21848320a44582ce1e2be53d