### PR TITLE
Remove integrations dependency from deploy-mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,6 @@ dependencies = [
  "axum-extra",
  "dioxus",
  "dioxus-ssr",
- "integrations",
  "mcp",
  "pulldown-cmark",
  "serde",

--- a/crates/deploy-mcp/Cargo.toml
+++ b/crates/deploy-mcp/Cargo.toml
@@ -19,5 +19,4 @@ syntect = "5.0"
 pulldown-cmark = "0.12.2"
 tower-livereload = "0.9.5"
 static-website = { path = "../static-website" }
-integrations = { path = "../integrations" }
 mcp = { path = "../mcp" }


### PR DESCRIPTION
## Summary
- remove the integrations path dependency so deploy-mcp no longer pulls the database stack
- parse MCP server metadata directly from the OpenAPI JSON value with local helpers

## Testing
- cargo check -p deploy-mcp

------
https://chatgpt.com/codex/tasks/task_e_68d62fd3196c8320ad01fe13a0ea02f6