### PR TITLE
Fix Cloudflare build script Tailwind invocation

### DIFF
--- a/crates/deploy-mcp/cloudflare-build.sh
+++ b/crates/deploy-mcp/cloudflare-build.sh
@@ -1,13 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
 curl -OL https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/download/tailwindcss-extra-linux-x64
 chmod +x tailwindcss-extra-linux-x64
-tailwind-extra -i ./deploy-mcp/input.css -o ./deploy-mcp/dist/tailwind.css --cwd ..
+./tailwindcss-extra-linux-x64 -i ./input.css -o ./dist/tailwind.css
+
 # Generate timestamp and rename tailwind.css file
 TIMESTAMP=$(date +%s)
 mv ./dist/tailwind.css ./dist/tailwind-${TIMESTAMP}.css
 
 # Update the reference in the source code
-sed -i "s|/tailwind\.css|/tailwind-${TIMESTAMP}.css|g" src/layouts/layout.rs
+sed -i "s|/tailwind\\.css|/tailwind-${TIMESTAMP}.css|g" src/layouts/layout.rs
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-. $HOME/.cargo/env
+. "$HOME/.cargo/env"
+
 cargo run


### PR DESCRIPTION
## Summary
- ensure the Cloudflare build script executes the downloaded Tailwind binary from the crate directory
- add basic shell safety options and local path handling for downstream operations

## Testing
- DO_NOT_RUN_SERVER=1 ./cloudflare-build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d639f5ad5483209d7d770e8d08406b