### PR TITLE
Rename collaborator document permission to ManageDocumentPipelines

### DIFF
--- a/crates/db/authz.rs
+++ b/crates/db/authz.rs
@@ -181,6 +181,10 @@ impl Rbac {
         self.permissions.contains(&Permission::DeleteChat)
     }
 
+    pub fn can_view_chats(&self) -> bool {
+        self.permissions.contains(&Permission::ViewChats)
+    }
+
     pub fn can_make_invitations(&self) -> bool {
         self.permissions.contains(&Permission::InvitePeopleToTeam)
     }
@@ -191,6 +195,11 @@ impl Rbac {
 
     pub fn can_manage_datasets(&self) -> bool {
         self.permissions.contains(&Permission::ManageDatasets)
+    }
+
+    pub fn can_manage_document_pipelines(&self) -> bool {
+        self.permissions
+            .contains(&Permission::ManageDocumentPipelines)
     }
 
     pub fn can_view_prompts(&self) -> bool {

--- a/crates/db/migrations/20250531133410_collaborator_chat_document_permissions.sql
+++ b/crates/db/migrations/20250531133410_collaborator_chat_document_permissions.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+ALTER TYPE permission ADD VALUE IF NOT EXISTS 'ViewChats';
+ALTER TYPE permission ADD VALUE IF NOT EXISTS 'ManageDocumentPipelines';
+
+INSERT INTO roles_permissions VALUES('Collaborator', 'ViewChats');
+INSERT INTO roles_permissions VALUES('Collaborator', 'ManageDocumentPipelines');
+
+-- migrate:down
+DELETE FROM roles_permissions WHERE role = 'Collaborator' AND permission = 'ViewChats';
+DELETE FROM roles_permissions WHERE role = 'Collaborator' AND permission = 'ManageDocumentPipelines';

--- a/crates/static-website/content/docs/on-premise/rbac/index.md
+++ b/crates/static-website/content/docs/on-premise/rbac/index.md
@@ -30,7 +30,7 @@ SELECT enum_range(NULL::permission);
 
 {InvitePeopleToTeam,ViewCurrentTeam,ViewPrompts,ManagePipelines,
 ViewDatasets,ManageDatasets,CreateApiKeys,ViewAuditTrail,SetupMod
-els}
+els,ViewChats,ManageDocumentPipelines}
 ```
 
 ### View all the roles
@@ -49,7 +49,7 @@ bionicgpt=#
 
 ```sql
 bionicgpt=# select * from roles_permissions;
-        role         |     permission     
+        role         |     permission
 ---------------------+--------------------
  TeamManager         | InvitePeopleToTeam
  SystemAdministrator | ViewAuditTrail
@@ -59,7 +59,9 @@ bionicgpt=# select * from roles_permissions;
  Collaborator        | ManageDatasets
  Collaborator        | ViewDatasets
  Collaborator        | CreateApiKeys
-(8 rows)
+ Collaborator        | ViewChats
+ Collaborator        | ManageDocumentPipelines
+(10 rows)
 ```
 
 So finally, any permissions you don't want **Team Collaborators** to have, you could transfer to the **System Administrator**.


### PR DESCRIPTION
## Summary
- add migrations to introduce ViewChats and ManageDocumentPipelines permissions for collaborators
- expose helper methods in the RBAC helper to check the new permissions
- document the new collaborator permissions in the RBAC reference guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ff9abf888320b646cdb30ba89fa5