### PR TITLE
Add licence-aware AI assistant labels

### DIFF
--- a/crates/db/licence.rs
+++ b/crates/db/licence.rs
@@ -21,6 +21,8 @@ pub struct Licence {
     pub signature: String,
     pub app_name: String,
     pub app_logo_svg: String,
+    #[serde(default)]
+    pub default_lang: String,
 }
 
 fn deserialize_rfc3339<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
@@ -43,6 +45,7 @@ impl Default for Licence {
             signature: String::new(),
             app_name: String::new(),
             app_logo_svg: String::new(),
+            default_lang: String::new(),
         }
     }
 }

--- a/crates/web-pages/app_layout.rs
+++ b/crates/web-pages/app_layout.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 use super::snackbar::Snackbar;
 use crate::components::logout_form::LogoutForm;
+use crate::i18n;
 use crate::menu::{NavGroup, NavItem};
 use crate::profile_popup::ProfilePopup;
 use assets::files::*;
@@ -88,7 +89,7 @@ pub fn Layout(props: LayoutProps) -> Element {
                 }
                 if props.rbac.can_view_datasets() || props.rbac.can_view_integrations() {
                     NavGroup {
-                        heading: "AI Assistants",
+                        heading: i18n::ai_assistants().to_string(),
                         content:  rsx!(
                             if props.rbac.can_view_prompts() {
                                 NavItem {
@@ -105,7 +106,7 @@ pub fn Layout(props: LayoutProps) -> Element {
                                     selected_item_id: props.selected_item.to_string(),
                                     href: super::routes::integrations::Index { team_id: props.team_id },
                                     icon: nav_audit_svg.name,
-                                    title: "Integrations"
+                                    title: i18n::integrations().to_string()
                                 }
                             }
                             if props.rbac.can_view_datasets() {

--- a/crates/web-pages/i18n.rs
+++ b/crates/web-pages/i18n.rs
@@ -1,0 +1,15 @@
+use db::Licence;
+
+pub fn ai_assistants() -> &'static str {
+    match Licence::global().default_lang.as_str() {
+        "en-US" => "MCP Servers",
+        _ => "AI Assistants",
+    }
+}
+
+pub fn integrations() -> &'static str {
+    match Licence::global().default_lang.as_str() {
+        "en-US" => "MCP Servers",
+        _ => "Integrations",
+    }
+}

--- a/crates/web-pages/lib.rs
+++ b/crates/web-pages/lib.rs
@@ -14,6 +14,7 @@ pub mod console;
 pub mod datasets;
 pub mod documents;
 pub mod history;
+pub mod i18n;
 pub mod integrations;
 pub mod licence;
 pub mod menu;


### PR DESCRIPTION
## Summary
- add a default_lang field to the cached licence data model
- add i18n helpers for assistant and integration labels that respect the licence language
- update the app layout to source the AI Assistants navigation labels from the new helpers

## Testing
- cargo fmt
- cargo check -p web-pages

------
https://chatgpt.com/codex/tasks/task_e_68d913fb60988320ad65bb4ea8a785e8