### PR TITLE
[ci skip] Use i18n integrations label across integration pages

### DIFF
--- a/crates/web-pages/integrations/page.rs
+++ b/crates/web-pages/integrations/page.rs
@@ -15,11 +15,11 @@ pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<IntegrationSummary>) -> 
             selected_item: SideBar::Integrations,
             team_id: team_id,
             rbac: rbac.clone(),
-            title: "Integrations",
+            title: crate::i18n::integrations().to_string(),
             header: rsx!(
                 Breadcrumb {
                     items: vec![BreadcrumbItem {
-                        text: "Integrations".into(),
+                        text: crate::i18n::integrations().into(),
                         href: Some(crate::routes::integrations::Index { team_id }.to_string())
                     }]
                 }
@@ -37,7 +37,7 @@ pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<IntegrationSummary>) -> 
             div {
                 class: "p-4 max-w-3xl w-full mx-auto",
                 SectionIntroduction {
-                    header: "Integrations".to_string(),
+                    header: crate::i18n::integrations().to_string(),
                     subtitle: "Connect external tools to retrieve data, take actions, and more.".to_string(),
                     is_empty: integrations.is_empty(),
                     empty_text: "No integrations have been configured yet. Add your first integration to get started.".to_string(),

--- a/crates/web-pages/integrations/upsert.rs
+++ b/crates/web-pages/integrations/upsert.rs
@@ -25,11 +25,11 @@ pub fn page(team_id: i32, rbac: Rbac, integration: IntegrationForm) -> String {
             selected_item: SideBar::Integrations,
             team_id: team_id,
             rbac: rbac.clone(),
-            title: "Integrations",
+            title: crate::i18n::integrations().to_string(),
             header: rsx!(
                 Breadcrumb {
                     items: vec![BreadcrumbItem {
-                        text: "Integrations".into(),
+                        text: crate::i18n::integrations().into(),
                         href: None
                     }]
                 }
@@ -37,7 +37,7 @@ pub fn page(team_id: i32, rbac: Rbac, integration: IntegrationForm) -> String {
 
             Card {
                 CardHeader {
-                    title: "Integrations"
+                    title: crate::i18n::integrations().to_string()
                 }
                 CardBody {
                     form {

--- a/crates/web-pages/integrations/view.rs
+++ b/crates/web-pages/integrations/view.rs
@@ -26,12 +26,12 @@ pub fn view(
             selected_item: SideBar::Integrations,
             team_id: team_id,
             rbac: rbac.clone(),
-            title: "Integrations",
+            title: crate::i18n::integrations().to_string(),
             header: rsx!(
                 Breadcrumb {
                     items: vec![
                             BreadcrumbItem {
-                            text: "Integrations".into(),
+                            text: crate::i18n::integrations().into(),
                             href: Some(crate::routes::integrations::Index { team_id }.to_string())
                         },
                         BreadcrumbItem {


### PR DESCRIPTION
## Summary
- replace hard-coded "Integrations" labels in the integrations pages with the shared i18n helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91c026d4c8320a25d245eb526ae1a