### PR TITLE
[ci skip] Add prebuilt integration selection flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5431,6 +5450,7 @@ dependencies = [
  "db",
  "embeddings-api",
  "http 1.1.0",
+ "include_dir",
  "integrations",
  "lettre",
  "llm-proxy",

--- a/crates/web-pages/integrations/mod.rs
+++ b/crates/web-pages/integrations/mod.rs
@@ -9,5 +9,6 @@ pub mod oauth2_cards;
 pub mod oauth_connect_button;
 pub mod page;
 pub mod parameter_renderer;
+pub mod select;
 pub mod upsert;
 pub mod view;

--- a/crates/web-pages/integrations/page.rs
+++ b/crates/web-pages/integrations/page.rs
@@ -10,7 +10,7 @@ use db::authz::Rbac;
 use dioxus::prelude::*;
 
 pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<IntegrationSummary>) -> String {
-    let button_name = format!("Add {}", i18n::integration());
+    let button_name = format!("Select {}", i18n::integration());
     let page = rsx! {
         Layout {
             section_class: "p-4",
@@ -29,7 +29,7 @@ pub fn page(team_id: i32, rbac: Rbac, integrations: Vec<IntegrationSummary>) -> 
                     Button {
                         button_type: ButtonType::Link,
                         prefix_image_src: "{button_plus_svg.name}",
-                        href: routes::integrations::New{team_id}.to_string(),
+                        href: routes::integrations::Select { team_id }.to_string(),
                         button_scheme: ButtonScheme::Primary,
                         "{button_name}"
                     }

--- a/crates/web-pages/integrations/select.rs
+++ b/crates/web-pages/integrations/select.rs
@@ -1,0 +1,111 @@
+#![allow(non_snake_case)]
+use crate::app_layout::{Layout, SideBar};
+use crate::i18n;
+use crate::routes;
+use daisy_rsx::*;
+use db::authz::Rbac;
+use dioxus::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrebuiltSpec {
+    pub file_name: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub spec_json: String,
+}
+
+pub fn page(team_id: i32, rbac: Rbac, specs: Vec<PrebuiltSpec>) -> String {
+    let private_visibility = crate::visibility_to_string(db::Visibility::Private);
+    let page = rsx! {
+        Layout {
+            section_class: "p-4",
+            selected_item: SideBar::Integrations,
+            team_id: team_id,
+            rbac: rbac.clone(),
+            title: crate::i18n::integrations().to_string(),
+            header: rsx!(
+                Breadcrumb {
+                    items: vec![
+                        BreadcrumbItem {
+                            text: crate::i18n::integrations().into(),
+                            href: Some(routes::integrations::Index { team_id }.to_string()),
+                        },
+                        BreadcrumbItem {
+                            text: "Select Integration".into(),
+                            href: None,
+                        }
+                    ]
+                }
+                Button {
+                    button_type: ButtonType::Link,
+                    button_scheme: ButtonScheme::Primary,
+                    href: routes::integrations::New { team_id }.to_string(),
+                    "Add Custom"
+                }
+            ),
+
+            Card {
+                CardHeader {
+                    title: format!("Select a {}", i18n::integration())
+                }
+                CardBody {
+                    if specs.is_empty() {
+                        div {
+                            class: "alert alert-warning",
+                            "No pre-built integrations are available right now."
+                        }
+                    } else {
+                        div {
+                            class: "grid grid-cols-1 gap-4 md:grid-cols-2",
+                            for spec in specs {
+                                Card {
+                                    class: "bg-base-100 shadow border border-base-300 h-full flex flex-col",
+                                    CardHeader {
+                                        title: spec.title.clone()
+                                    }
+                                    CardBody {
+                                        class: "flex-1 flex flex-col gap-4",
+                                        if let Some(description) = spec.description.clone() {
+                                            p {
+                                                class: "text-sm text-base-content/80",
+                                                "{description}"
+                                            }
+                                        }
+                                        p {
+                                            class: "text-xs text-base-content/60",
+                                            "Source: {spec.file_name}.json"
+                                        }
+                                        div {
+                                            class: "mt-auto",
+                                            form {
+                                                method: "post",
+                                                action: routes::integrations::New { team_id }.to_string(),
+                                                input {
+                                                    r#type: "hidden",
+                                                    name: "visibility",
+                                                    value: private_visibility.clone(),
+                                                }
+                                                textarea {
+                                                    class: "hidden",
+                                                    name: "openapi_spec",
+                                                    "{spec.spec_json}"
+                                                }
+                                                Button {
+                                                    button_type: ButtonType::Submit,
+                                                    button_scheme: ButtonScheme::Primary,
+                                                    "Create Integration"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    crate::render(page)
+}

--- a/crates/web-pages/routes.rs
+++ b/crates/web-pages/routes.rs
@@ -399,6 +399,12 @@ pub mod integrations {
     }
 
     #[derive(TypedPath, Deserialize)]
+    #[typed_path("/app/team/{team_id}/integrations/select")]
+    pub struct Select {
+        pub team_id: i32,
+    }
+
+    #[derive(TypedPath, Deserialize)]
     #[typed_path("/app/team/{team_id}/integrations/edit/{id}")]
     pub struct Edit {
         pub team_id: i32,

--- a/crates/web-server/Cargo.toml
+++ b/crates/web-server/Cargo.toml
@@ -54,6 +54,7 @@ oauth2 = { version = "5.0.0", features = ["reqwest"] }
 chrono = { version = "0.4", features = ["serde"] }
 time = { version = "0.3", features = ["serde"] }
 url = "2.4"
+include_dir = "0.7"
 
 [dev-dependencies]
 time = "0.3.36"

--- a/crates/web-server/handlers/integrations/mod.rs
+++ b/crates/web-server/handlers/integrations/mod.rs
@@ -14,7 +14,7 @@ pub use configuration_actions::{
     ApiKeyForm,
 };
 pub use helpers::parse_openapi_spec;
-pub use loaders::{edit_loader, loader, new_loader, view_loader};
+pub use loaders::{edit_loader, loader, new_loader, select_loader, view_loader};
 
 pub fn routes() -> Router {
     Router::new()
@@ -22,6 +22,7 @@ pub fn routes() -> Router {
         .typed_get(loader)
         .typed_get(view_loader)
         .typed_get(new_loader)
+        .typed_get(select_loader)
         .typed_get(edit_loader)
         // Actions
         .typed_post(new_action)


### PR DESCRIPTION
## Summary
- add a prebuilt integration selection page that lists bundled OpenAPI specs as cards
- wire a new select route and loader so choosing a card posts directly to the existing integration creation flow
- bundle the MCP specs at build time via include_dir and expose the selection entry point from the integrations index

## Testing
- cargo fmt
- cargo check -p web-server

------
https://chatgpt.com/codex/tasks/task_e_68da2e6ccbd0832081ac0bd8ae08433d