### PR TITLE
Add logos to integration selection cards

### DIFF
--- a/crates/web-pages/integrations/select.rs
+++ b/crates/web-pages/integrations/select.rs
@@ -12,6 +12,7 @@ pub struct PrebuiltSpec {
     pub title: String,
     pub description: Option<String>,
     pub spec_json: String,
+    pub logo_data_url: Option<String>,
 }
 
 pub fn page(team_id: i32, rbac: Rbac, specs: Vec<PrebuiltSpec>) -> String {
@@ -65,6 +66,16 @@ pub fn page(team_id: i32, rbac: Rbac, specs: Vec<PrebuiltSpec>) -> String {
                                     }
                                     CardBody {
                                         class: "flex-1 flex flex-col gap-4",
+                                        if let Some(logo_url) = spec.logo_data_url.clone() {
+                                            div {
+                                                class: "flex justify-center",
+                                                img {
+                                                    class: "h-16 w-auto object-contain",
+                                                    src: "{logo_url}",
+                                                    alt: format!("{} logo", spec.title),
+                                                }
+                                            }
+                                        }
                                         if let Some(description) = spec.description.clone() {
                                             p {
                                                 class: "text-sm text-base-content/80",

--- a/crates/web-server/handlers/integrations/loaders.rs
+++ b/crates/web-server/handlers/integrations/loaders.rs
@@ -250,6 +250,16 @@ pub async fn select_loader(
                             .and_then(|desc| desc.as_str())
                             .map(|desc| desc.to_string());
 
+                        let logo_data_url = value
+                            .get("info")
+                            .and_then(|info| info.get("x-logo"))
+                            .and_then(|logo| {
+                                logo.get("url")
+                                    .and_then(|url| url.as_str())
+                                    .map(|url| url.to_string())
+                                    .or_else(|| logo.as_str().map(|url| url.to_string()))
+                            });
+
                         let spec_json =
                             serde_json::to_string(&value).unwrap_or_else(|_| contents.to_string());
 
@@ -262,6 +272,7 @@ pub async fn select_loader(
                             title,
                             description,
                             spec_json,
+                            logo_data_url,
                         }
                     })
                 })


### PR DESCRIPTION
## Summary
- parse optional `x-logo` URLs when loading prebuilt MCP specs
- render available spec logos within the integration selection cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da34c9a6388320ba3323bebbf9d7b3