### PR TITLE
Add MCP JSON-RPC handler stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,6 +5485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "validator",
  "web-pages",
 ]

--- a/crates/web-server/Cargo.toml
+++ b/crates/web-server/Cargo.toml
@@ -55,6 +55,7 @@ chrono = { version = "0.4", features = ["serde"] }
 time = { version = "0.3", features = ["serde"] }
 url = "2.4"
 include_dir = "0.7"
+uuid = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
 time = "0.3.36"

--- a/crates/web-server/handlers/mcp/mod.rs
+++ b/crates/web-server/handlers/mcp/mod.rs
@@ -1,0 +1,93 @@
+use crate::CustomError;
+use axum::{extract::Extension, http::StatusCode, response::IntoResponse, Json, Router};
+use axum_extra::routing::{RouterExt, TypedPath};
+use db::Pool;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+const API_KEY_CONNECTION_LOOKUP: &str = r#"
+    SELECT 1
+    FROM integrations i
+    JOIN api_key_connections c ON c.integration_id = i.id
+    WHERE LOWER(COALESCE(i.definition->'info'->>'x-bionic-slug', i.definition->'info'->>'bionic-slug')) = LOWER($1)
+      AND c.external_id = $2
+    LIMIT 1
+"#;
+
+const OAUTH2_CONNECTION_LOOKUP: &str = r#"
+    SELECT 1
+    FROM integrations i
+    JOIN oauth2_connections c ON c.integration_id = i.id
+    WHERE LOWER(COALESCE(i.definition->'info'->>'x-bionic-slug', i.definition->'info'->>'bionic-slug')) = LOWER($1)
+      AND c.external_id = $2
+    LIMIT 1
+"#;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/v1/mcp/{slug}/{connection_id}")]
+pub struct JsonRpcPath {
+    pub slug: String,
+    pub connection_id: Uuid,
+}
+
+pub fn routes() -> Router {
+    Router::new().typed_post(handle_json_rpc)
+}
+
+pub async fn handle_json_rpc(
+    JsonRpcPath {
+        slug,
+        connection_id,
+    }: JsonRpcPath,
+    Extension(pool): Extension<Pool>,
+    Json(payload): Json<Value>,
+) -> Result<impl IntoResponse, CustomError> {
+    let mut client = pool.get().await?;
+    let slug_param = slug.to_ascii_lowercase();
+
+    let mut connection_exists = client
+        .query_opt(API_KEY_CONNECTION_LOOKUP, &[&slug_param, &connection_id])
+        .await?
+        .is_some();
+
+    if !connection_exists {
+        connection_exists = client
+            .query_opt(OAUTH2_CONNECTION_LOOKUP, &[&slug_param, &connection_id])
+            .await?
+            .is_some();
+    }
+
+    if !connection_exists {
+        let response = json!({
+            "jsonrpc": payload
+                .get("jsonrpc")
+                .and_then(|value| value.as_str())
+                .unwrap_or("2.0"),
+            "id": payload.get("id").cloned().unwrap_or(Value::Null),
+            "error": {
+                "code": -32004,
+                "message": format!(
+                    "Unknown MCP connection {} for integration slug {}",
+                    connection_id, slug
+                ),
+            }
+        });
+
+        return Ok((StatusCode::NOT_FOUND, Json(response)));
+    }
+
+    let response = json!({
+        "jsonrpc": payload
+            .get("jsonrpc")
+            .and_then(|value| value.as_str())
+            .unwrap_or("2.0"),
+        "id": payload.get("id").cloned().unwrap_or(Value::Null),
+        "error": {
+            "code": -32601,
+            "message": "MCP JSON-RPC handling is not implemented yet",
+        }
+    });
+
+    Ok((StatusCode::OK, Json(response)))
+}

--- a/crates/web-server/handlers/mod.rs
+++ b/crates/web-server/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod documents;
 pub mod history;
 pub mod integrations;
 pub mod licence;
+pub mod mcp;
 pub mod metrics;
 pub mod models;
 pub mod my_assistants;

--- a/crates/web-server/main.rs
+++ b/crates/web-server/main.rs
@@ -93,6 +93,7 @@ async fn main() {
         .merge(handlers::oauth2::routes())
         .merge(handlers::oauth_clients::routes())
         .merge(llm_proxy::routes())
+        .merge(handlers::mcp::routes())
         .merge(handlers::models::routes())
         .merge(handlers::categories::routes())
         .merge(handlers::pipelines::routes())


### PR DESCRIPTION
## Summary
- add an MCP handler module with a typed POST route at `/v1/mcp/{slug}/{connection_id}`
- look up integration connections to return a JSON-RPC 404 error when the slug or connection cannot be resolved
- register the handler with the web-server router and add the `uuid` dependency needed for typed path parsing

## Testing
- `cargo fmt`
- `cargo check -p web-server` *(fails: crates/db build script requires a DATABASE_URL for cornucopia)*

------
https://chatgpt.com/codex/tasks/task_e_68da6caf6cfc83208d91cfef05272c29