### PR TITLE
Fix MCP URL modals to wrap long links

### DIFF
--- a/crates/web-pages/integrations/api_key_cards.rs
+++ b/crates/web-pages/integrations/api_key_cards.rs
@@ -65,8 +65,10 @@ pub fn ApiKeyCards(
                                                     class: "text-sm text-base-content/70 mb-3",
                                                     "Use this URL to connect your MCP client to this API key connection."
                                                 }
-                                                pre {
-                                                    class: "bg-base-200 rounded p-3 text-sm break-all",
+                                                textarea {
+                                                    class: "textarea textarea-bordered w-full text-sm font-mono bg-base-200",
+                                                    readonly: true,
+                                                    rows: "3",
                                                     "{mcp_url}"
                                                 }
                                                 ModalAction {

--- a/crates/web-pages/integrations/oauth2_cards.rs
+++ b/crates/web-pages/integrations/oauth2_cards.rs
@@ -72,8 +72,10 @@ pub fn Oauth2Cards(
                                                     class: "text-sm text-base-content/70 mb-3",
                                                     "Use this URL to connect your MCP client to this OAuth2 connection."
                                                 }
-                                                pre {
-                                                    class: "bg-base-200 rounded p-3 text-sm break-all",
+                                                textarea {
+                                                    class: "textarea textarea-bordered w-full text-sm font-mono bg-base-200",
+                                                    readonly: true,
+                                                    rows: "3",
                                                     "{mcp_url}"
                                                 }
                                                 ModalAction {


### PR DESCRIPTION
## Summary
- replace MCP URL <pre> blocks in API key and OAuth2 integration modals with read-only textareas
- ensure long URLs wrap across lines to avoid overflow

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68da7f5fcc1883209e86e5a26052af2d