### PR TITLE
feat: add OrcaRouter as a seeded provider

### DIFF
--- a/crates/bionic-gpt/content/.spelling
+++ b/crates/bionic-gpt/content/.spelling
@@ -160,6 +160,7 @@ socioeconomic
 lakehouse
  - blog/api-chatbot/index.md
 OpenAI-compatible
+OrcaRouter
 secrets.toml
 streamlit
  - blog/confidential-saas/index.md

--- a/crates/bionic-gpt/content/docs/guides/managing-models/index.md
+++ b/crates/bionic-gpt/content/docs/guides/managing-models/index.md
@@ -12,6 +12,14 @@ For externally hosted model, one that's not running in your Kubernetes cluster. 
 
 Great news. Add the URL for your provider and any API keys directly into the models section of the user interface.
 
+For example, to use **[OrcaRouter](https://www.orcarouter.ai)** as your gateway provider:
+
+1. In **Models**, choose **Select Provider** → **OrcaRouter**.
+2. The default model is `orcarouter/auto`, which routes each request to the best model for the job.
+3. Paste your OrcaRouter API key (`sk-orca-...`). OrcaRouter exposes an OpenAI-compatible endpoint at `https://api.orcarouter.ai/v1`.
+
+OrcaRouter is a gateway that also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
 ![Alt text](bionic-setup.png "Adding Models")
 
 ## For providers that don't support the Open AI `chat/completions` API (Work in Progress)

--- a/crates/db/migrations/20260819090000_add_orcarouter_provider.sql
+++ b/crates/db/migrations/20260819090000_add_orcarouter_provider.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+INSERT INTO model_registry.providers (
+    name,
+    svg_logo,
+    default_model_name,
+    default_model_display_name,
+    default_model_context_size,
+    default_model_description,
+    base_url
+) VALUES (
+    'OrcaRouter',
+    '<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path fill="#0B1220" d="M64 224c0-88 72-160 160-160h64c88 0 160 72 160 160v80c0 88-72 160-160 160h-64C136 464 64 392 64 304v-80zm160-96c-53 0-96 43-96 96v80c0 53 43 96 96 96h64c53 0 96-43 96-96v-80c0-53-43-96-96-96h-64z"/><path fill="#FFFFFF" d="M176 208c0-26 22-48 48-48h64c26 0 48 22 48 48v96c0 26-22 48-48 48h-64c-26 0-48-22-48-48v-96z"/><path fill="#0B1220" d="M176 208h-32v96h32v-96zm160 0h32v96h-32v-96z"/><path fill="#1DA1F2" d="M256 128v256"/></svg>',
+    'orcarouter/auto',
+    'OrcaRouter Auto',
+    131072,
+    'OrcaRouter is an OpenAI-compatible model gateway that routes each request to the best model for the job. It also runs gateway-level, zero-trust security for AI agents on the same endpoint.',
+    'https://api.orcarouter.ai/v1'
+);
+
+-- migrate:down
+DELETE FROM model_registry.providers WHERE name = 'OrcaRouter';


### PR DESCRIPTION
## Summary

Add **OrcaRouter** as a seeded provider in the Bionic provider catalog so it appears in **Models → Select Provider** alongside OpenAI, Groq, OpenRouter, Ollama and Doubleword.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway that routes each request to the best model for the job. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`crates/db/migrations/20260819090000_add_orcarouter_provider.sql`** — new migration seeding the `OrcaRouter` provider in `model_registry.providers`:
  - `base_url`: `https://api.orcarouter.ai/v1`
  - default model: `orcarouter/auto` (routing model), context size `131072`
- **`crates/bionic-gpt/content/docs/guides/managing-models/index.md`** — document OrcaRouter as a gateway provider option.
- **`crates/bionic-gpt/content/.spelling`** — add `OrcaRouter` to the markdown spellcheck dictionary.

## Verification

- Migration mirrors the existing provider seed pattern (same columns, `dbmate`-compatible up/down).
- The default `base_url`/model were live-tested against the real endpoint: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returns `200`.

Disclosure: I'm an engineer on the OrcaRouter team.
