### PR TITLE
feat: add llmman as a local model provider

### DIFF
--- a/crates/bionic-gpt/content/.spelling
+++ b/crates/bionic-gpt/content/.spelling
@@ -116,6 +116,7 @@ RBAC
 TGI
 OSX
 Ollama
+llmman
 0
 100
 95

--- a/crates/bionic-gpt/content/docs/running-locally/llmman/index.md
+++ b/crates/bionic-gpt/content/docs/running-locally/llmman/index.md
@@ -1,0 +1,55 @@
+# llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port `17434`. Models are pulled as OCI artifacts or straight from Hugging Face and served by `llama.cpp`, `vllm` or `mlx-lm`.
+
+Because llmman speaks the Ollama API, Bionic connects to it with the built in `Ollama` adapter. The only difference is the port.
+
+## Install and start llmman
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman serve
+```
+
+## Configuring llmman to listen on `0.0.0.0`.
+
+By default llmman binds to `127.0.0.1:17434`. Services from within `k3s` or docker compose can't reach that, so start it with `LLMMAN_HOST` set:
+
+```bash
+LLMMAN_HOST=0.0.0.0 llmman serve
+```
+
+## Run a model
+
+```sh
+llmman pull gemma4
+llmman run gemma4
+```
+
+## Test llmman
+
+Run the following to see `llmman` generate some output.
+
+```sh
+curl http://localhost:17434/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "gemma4",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful AI agent."
+            },
+            {
+                "role": "user",
+                "content": "Hello!"
+            }
+        ]
+    }'
+```
+
+## Add the model in Bionic
+
+From the models screen pick the `llmman (Local)` provider. No API key is needed.
+
+If Bionic is running inside `k3s` change the URL from `http://host.docker.internal:17434/v1` to `http://hostname:17434/v1`. Where host name is the name you get when your run `hostname`.

--- a/crates/bionic-gpt/src/docs_summary.rs
+++ b/crates/bionic-gpt/src/docs_summary.rs
@@ -107,6 +107,17 @@ pub fn summary() -> Summary {
                         author_image: None,
                         author: None,
                     },
+                    PageSummary {
+                        date: "",
+                        title: "Connecting to llmman",
+                        description: "Connecting to llmman",
+                        folder: "docs/running-locally/llmman/",
+                        markdown: include_str!("../content/docs/running-locally/llmman/index.md"),
+                        image: None,
+                        open_graph_image: None,
+                        author_image: None,
+                        author: None,
+                    },
                 ],
             },
             Category {

--- a/crates/db/migrations/20260904090000_add-llmman-provider.sql
+++ b/crates/db/migrations/20260904090000_add-llmman-provider.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+-- llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on port
+-- 17434, so it reuses the existing Ollama adapter; the logo is a neutral placeholder.
+INSERT INTO model_registry.providers (
+    name,
+    svg_logo,
+    default_model_name,
+    default_model_display_name,
+    default_model_context_size,
+    default_model_description,
+    base_url,
+    provider_type,
+    api_key_optional
+) VALUES (
+    'llmman (Local)',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><title>llmman</title><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M12 15h5"/></svg>',
+    'gemma4',
+    'Gemma 4',
+    32768,
+    'Local model served by llmman. Pull it first with `llmman pull gemma4`.',
+    'http://host.docker.internal:17434/v1',
+    'Ollama',
+    true
+);
+
+-- migrate:down
+DELETE FROM model_registry.providers WHERE name = 'llmman (Local)';


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- New migration `20260904090000_add-llmman-provider.sql` seeds an `llmman (Local)` provider with `provider_type = 'Ollama'` and `base_url = http://host.docker.internal:17434/v1`; the existing Ollama adapter works unchanged, no new Rust code path.
- `api_key_optional = true` since llmman needs no key; `svg_logo` is a neutral placeholder rather than another provider's mark.
- New docs page `docs/running-locally/llmman/index.md` mirroring the Ollama one, registered in `docs_summary.rs`; `llmman` added to `.spelling`.
- Default model `gemma4` with a 32768 context size; happy to adjust.

**Testing:** `cargo fmt -p bionic-gpt -- --check` and `cargo check -p bionic-gpt` pass; migration `up`/`down` applied against a scratch `postgres:16-alpine` with the `model_registry.providers` table recreated. Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
